### PR TITLE
Updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Extension authors (not package contributors) use:
 - [Agent-Assisted Development](docs/guides/agent-assisted-development.md)
 - [VS Code API Mapping](docs/reference/vscode-api-mapping.md)
 - [Consumer AGENTS.md template](docs/templates/consumer-agents.md)
-- Skills in [`skills/`](skills/) — copy to extension projects under `.cursor/skills/`
+- Skills in [`skills/`](skills/) — scaffolded into extension projects as `agent-skills/`
 
 For full detail, follow the linked topic pages under `docs/agent-guidelines/`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This file is the root index for AI and contributor documentation.
 - [Architecture](docs/architecture/index.md)
 - [Guides](docs/guides/index.md)
 - [Reference](docs/reference/index.md)
+- [Roadmap](docs/reference/roadmap.md)
 - [Contributing](docs/contributing/index.md)
 
 ## Root Project Documents

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,5 +31,14 @@ This file is the root index for AI and contributor documentation.
 - For generation errors, provide actionable user-facing failures.
 - Keep documentation and examples aligned with API behavior.
 
+## Consumer Agent Toolkit
+
+Extension authors (not package contributors) use:
+
+- [Agent-Assisted Development](docs/guides/agent-assisted-development.md)
+- [VS Code API Mapping](docs/reference/vscode-api-mapping.md)
+- [Consumer AGENTS.md template](docs/templates/consumer-agents.md)
+- Skills in [`skills/`](skills/) — copy to extension projects under `.cursor/skills/`
+
 For full detail, follow the linked topic pages under `docs/agent-guidelines/`.
 

--- a/PRD.md
+++ b/PRD.md
@@ -225,6 +225,7 @@ These are initial, high-level indicators; they can be refined once we have real 
   - How opinionated should we be about project layout beyond the basics?
 
 - **Future directions**
+  - **Tiered integration testing** (next priority): CI build smoke on `example/`, local extension-host checklist, periodic greenfield regression. See [docs/reference/roadmap.md](docs/reference/roadmap.md).
   - Additional templates and generators (e.g., opinionated starters for dashboards, inspectors, or wizards).
   - Richer tooling around the generator (e.g., validation commands, health checks, code actions).
   - More comprehensive examples and tutorial-style documentation to showcase best practices.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ and a scaffold command so you can avoid hand-written webview wiring.
 - Runtime request/response messaging between Flutter webview code and VS Code extension host.
 - Scaffold CLI: `dart run flutter_vscode:generate_vscode_extension`.
 - Webview-safe default build assets and compile script.
+- **Agent toolkit:** curated skills and `AGENTS.md` template so AI agents handle VS Code API translation (see [Agent-Assisted Development](docs/guides/agent-assisted-development.md)).
 
 ## Prerequisites
 
@@ -79,6 +80,19 @@ npm run compile
 
 7. Open the extension project in VS Code and press F5.
 
+## Agent-assisted development
+
+The scaffold command copies an agent toolkit into your extension project:
+
+- `AGENTS.md` — rules for AI agents working in your extension
+- `.cursor/skills/` — flutter_vscode skills (add commands, build, troubleshoot)
+
+Describe VS Code behavior in plain language; your agent adds annotations and
+runs the build pipeline. See [Agent-Assisted Development](docs/guides/agent-assisted-development.md)
+and [VS Code API Mapping](docs/reference/vscode-api-mapping.md).
+
+To install skills globally: `cp -r skills/* ~/.cursor/skills/`
+
 ## Build pipeline
 
 The default compile flow is:
@@ -93,6 +107,8 @@ The default compile flow is:
   - `*.vscode.g.part`
   - `*.handlers.ts`
 - Created once by scaffold (not overwritten by default on rerun):
+  - `AGENTS.md`
+  - `.cursor/skills/`
   - `src/extension.ts`
   - `package.json`
   - `tsconfig.json`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and a scaffold command so you can avoid hand-written webview wiring.
 - Scaffold CLI: `dart run flutter_vscode:generate_vscode_extension`.
 - Webview-safe default build assets and compile script.
 - **Agent toolkit:** curated skills and `AGENTS.md` template so AI agents handle VS Code API translation (see [Agent-Assisted Development](docs/guides/agent-assisted-development.md)).
+- **Dynamic invoke:** `VSCode.instance.invoke('window.showInputBox', [...])` for VS Code API calls without `build_runner` (see [Message Contract](docs/reference/message-contract.md)).
 
 ## Prerequisites
 
@@ -109,6 +110,7 @@ The default compile flow is:
 - Created once by scaffold (not overwritten by default on rerun):
   - `AGENTS.md`
   - `.cursor/skills/`
+  - `src/vscode_invoke.ts`
   - `src/extension.ts`
   - `package.json`
   - `tsconfig.json`

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm install
 4. Define controller API in Dart:
 
 ```dart
-import 'package:flutter_vscode/flutter_vscode.dart';
+import 'package:flutter_vscode/runtime.dart';
 
 part 'vscode_api.vscode.g.part';
 
@@ -100,6 +100,16 @@ The default compile flow is:
   - `lib/vscode_api.dart`
 - Merge behavior:
   - `.gitignore` entries are appended when missing.
+
+## Example project
+
+The `example/` directory is the integration fixture. Run its tests with:
+
+```bash
+cd example && flutter test
+```
+
+They are also included in `./scripts/test_all.sh`.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -83,16 +83,20 @@ npm run compile
 
 ## Agent-assisted development
 
-The scaffold command copies an agent toolkit into your extension project:
+The scaffold command copies a **portable agent toolkit** into your extension project:
 
-- `AGENTS.md` — rules for AI agents working in your extension
-- `.cursor/skills/` — flutter_vscode skills (add commands, build, troubleshoot)
+- `AGENTS.md` — project rules for AI coding agents (supported by many tools)
+- `agent-skills/` — workflow guides as plain markdown (`SKILL.md` files)
 
-Describe VS Code behavior in plain language; your agent adds annotations and
-runs the build pipeline. See [Agent-Assisted Development](docs/guides/agent-assisted-development.md)
-and [VS Code API Mapping](docs/reference/vscode-api-mapping.md).
+These work with any agent product that reads `AGENTS.md` or custom instructions
+(Cursor, Claude Code, GitHub Copilot, Windsurf, Cline, etc.). Wire skills into
+your tool if needed — for example, symlink or copy `agent-skills/*` into your
+product's skills directory, or `@`-reference the skill files in prompts.
 
-To install skills globally: `cp -r skills/* ~/.cursor/skills/`
+Describe VS Code behavior in plain language; your agent adds annotations, uses
+`VSCode.instance.invoke`, or runs the build pipeline. See
+[Agent-Assisted Development](docs/guides/agent-assisted-development.md) and
+[VS Code API Mapping](docs/reference/vscode-api-mapping.md).
 
 ## Build pipeline
 
@@ -109,7 +113,7 @@ The default compile flow is:
   - `*.handlers.ts`
 - Created once by scaffold (not overwritten by default on rerun):
   - `AGENTS.md`
-  - `.cursor/skills/`
+  - `agent-skills/`
   - `src/vscode_invoke.ts`
   - `src/extension.ts`
   - `package.json`

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The default compile flow is:
 ## Documentation
 
 - [Documentation Index](docs/index.md)
+- [Roadmap](docs/reference/roadmap.md)
 - [Architecture](docs/architecture/index.md)
 - [Guides](docs/guides/index.md)
 - [Reference](docs/reference/index.md)

--- a/bin/generate_vscode_extension.dart
+++ b/bin/generate_vscode_extension.dart
@@ -38,6 +38,7 @@ void main() {
     _createLaunchConfig(currentDirectory, summary);
     _createCompileScript(currentDirectory, summary);
     _createExtensionFile(currentDirectory, summary);
+    _createVscodeInvokeFile(currentDirectory, summary);
     _createVSCodeApiController(currentDirectory, summary);
     _createPackageJson(currentDirectory, summary);
     _createTsConfig(currentDirectory, summary);
@@ -217,6 +218,26 @@ void _createExtensionFile(String currentDirectory, _ScaffoldSummary summary) {
       summary: summary,
       policy: _WritePolicy.createOnly,
     );
+  }
+}
+
+void _createVscodeInvokeFile(
+  String currentDirectory,
+  _ScaffoldSummary summary,
+) {
+  final templatePath =
+      p.join(_flutterVscodePackageRoot(), 'tool', 'vscode_invoke.ts');
+  final file = File(p.join(currentDirectory, 'src', 'vscode_invoke.ts'));
+  if (File(templatePath).existsSync()) {
+    final content = File(templatePath).readAsStringSync();
+    _writeFile(
+      path: file.path,
+      contents: content,
+      summary: summary,
+      policy: _WritePolicy.createOnly,
+    );
+  } else {
+    summary.skipped.add('src/vscode_invoke.ts');
   }
 }
 

--- a/bin/generate_vscode_extension.dart
+++ b/bin/generate_vscode_extension.dart
@@ -42,6 +42,8 @@ void main() {
     _createPackageJson(currentDirectory, summary);
     _createTsConfig(currentDirectory, summary);
     _createWebFolder(currentDirectory, summary);
+    _createConsumerAgentsMd(currentDirectory, summary);
+    _copyAgentSkills(currentDirectory, summary);
     _updateGitignore(currentDirectory, summary);
 
     print('');
@@ -49,7 +51,11 @@ void main() {
     summary.printToStdout();
     print('Next steps:');
     print('1. Run: npm install');
-    print('2. Press F5 in VS Code to run the extension');
+    print('2. Run: dart run build_runner build --delete-conflicting-outputs');
+    print('3. Run: npm run compile');
+    print('4. Press F5 in VS Code to run the extension');
+    print('');
+    print('Agent toolkit: AGENTS.md and .cursor/skills/ are ready for AI-assisted development.');
   } on Object catch (e, stackTrace) {
     print('');
     print('❌ Error generating VSCode extension files:');
@@ -69,10 +75,104 @@ void main() {
 
 void _createDirectories(String currentDirectory) {
   Directory(p.join(currentDirectory, '.vscode')).createSync(recursive: true);
+  Directory(p.join(currentDirectory, '.cursor', 'skills'))
+      .createSync(recursive: true);
   Directory(p.join(currentDirectory, 'out')).createSync(recursive: true);
   Directory(p.join(currentDirectory, 'scripts')).createSync(recursive: true);
   Directory(p.join(currentDirectory, 'src')).createSync(recursive: true);
   Directory(p.join(currentDirectory, 'lib')).createSync(recursive: true);
+}
+
+void _createConsumerAgentsMd(
+  String currentDirectory,
+  _ScaffoldSummary summary,
+) {
+  final templateCandidates = [
+    p.join(_flutterVscodePackageRoot(), 'docs', 'templates', 'consumer-agents.md'),
+    p.join(_flutterVscodePackageRoot(), 'tool', 'consumer-agents.md.template'),
+  ];
+
+  String? contents;
+  for (final templatePath in templateCandidates) {
+    final templateFile = File(templatePath);
+    if (templateFile.existsSync()) {
+      contents = templateFile.readAsStringSync();
+      break;
+    }
+  }
+
+  if (contents == null) {
+    summary.skipped.add('AGENTS.md');
+    return;
+  }
+
+  _writeFile(
+    path: p.join(currentDirectory, 'AGENTS.md'),
+    contents: contents,
+    summary: summary,
+    policy: _WritePolicy.createOnly,
+  );
+}
+
+void _copyAgentSkills(String currentDirectory, _ScaffoldSummary summary) {
+  final skillsSource = Directory(
+    p.join(_flutterVscodePackageRoot(), 'skills'),
+  );
+  if (!skillsSource.existsSync()) {
+    summary.skipped.add('.cursor/skills/');
+    return;
+  }
+
+  final skillsTarget = p.join(currentDirectory, '.cursor', 'skills');
+  for (final entity in skillsSource.listSync()) {
+    if (entity is Directory) {
+      _copyDirectoryCreateOnly(
+        source: entity,
+        targetPath: p.join(skillsTarget, p.basename(entity.path)),
+        currentDirectory: currentDirectory,
+        summary: summary,
+      );
+    } else if (entity is File) {
+      final targetPath = p.join(skillsTarget, p.basename(entity.path));
+      if (File(targetPath).existsSync()) {
+        summary.skipped.add(p.relative(targetPath, from: currentDirectory));
+      } else {
+        entity.copySync(targetPath);
+        summary.created.add(p.relative(targetPath, from: currentDirectory));
+      }
+    }
+  }
+}
+
+void _copyDirectoryCreateOnly({
+  required Directory source,
+  required String targetPath,
+  required String currentDirectory,
+  required _ScaffoldSummary summary,
+}) {
+  final targetDir = Directory(targetPath);
+  if (!targetDir.existsSync()) {
+    targetDir.createSync(recursive: true);
+  }
+
+  for (final entity in source.listSync(recursive: true)) {
+    if (entity is! File) {
+      continue;
+    }
+
+    final relativePath = p.relative(entity.path, from: source.path);
+    final destination = p.join(targetPath, relativePath);
+    final destinationFile = File(destination);
+
+    if (destinationFile.existsSync()) {
+      summary.skipped.add(p.relative(destination, from: currentDirectory));
+      continue;
+    }
+
+    destinationFile.parent.createSync(recursive: true);
+    entity.copySync(destination);
+    summary.created.add(p.relative(destination, from: currentDirectory));
+  }
 }
 
 void _createLaunchConfig(String currentDirectory, _ScaffoldSummary summary) {
@@ -558,20 +658,36 @@ part 'vscode_api.vscode.g.part';
 /// Put your `@VSCodeController` classes in this file (or create more).
 ///
 /// Running:
-///   dart run build_runner build
+///   dart run build_runner build --delete-conflicting-outputs
 ///
 /// will generate:
 /// - `lib/vscode_api.vscode.g.part` (Dart implementation)
 /// - `lib/vscode_api.handlers.ts` (TypeScript handlers used by `src/extension.ts`)
+///
+/// More API patterns: see AGENTS.md and `.cursor/skills/flutter-vscode-add-command/`.
 @VSCodeController()
 abstract class VSCodeApi {
-  /// Calls `vscode.window.showInformationMessage(...)` in the extension host.
+  /// Calls `vscode.window.showInformationMessage(...)`.
   @VSCodeCommand('window.showInformationMessage')
   Future<void> info(String message);
 
-  /// Calls `vscode.window.showInputBox(...)` and returns the result.
+  /// Calls `vscode.window.showWarningMessage(...)`.
+  @VSCodeCommand('window.showWarningMessage')
+  Future<void> warning(String message);
+
+  /// Calls `vscode.window.showErrorMessage(...)`.
+  @VSCodeCommand('window.showErrorMessage')
+  Future<void> error(String message);
+
+  /// Calls `vscode.window.showInputBox(...)` with an options map.
+  ///
+  /// Example: `inputBox({'prompt': 'Name?', 'placeHolder': 'Jane Doe'})`
   @VSCodeCommand('window.showInputBox')
-  Future<String?> inputBox(String prompt);
+  Future<String?> inputBox(Map<String, dynamic> options);
+
+  /// Calls `vscode.window.showQuickPick(...)` with string items.
+  @VSCodeCommand('window.showQuickPick')
+  Future<String?> quickPick(List<String> items);
 }
 
 VSCodeApi createVSCodeApi() => _$VSCodeApi();

--- a/bin/generate_vscode_extension.dart
+++ b/bin/generate_vscode_extension.dart
@@ -56,7 +56,7 @@ void main() {
     print('3. Run: npm run compile');
     print('4. Press F5 in VS Code to run the extension');
     print('');
-    print('Agent toolkit: AGENTS.md and .cursor/skills/ are ready for AI-assisted development.');
+    print('Agent toolkit: AGENTS.md and agent-skills/ are ready for AI-assisted development.');
   } on Object catch (e, stackTrace) {
     print('');
     print('❌ Error generating VSCode extension files:');
@@ -76,7 +76,7 @@ void main() {
 
 void _createDirectories(String currentDirectory) {
   Directory(p.join(currentDirectory, '.vscode')).createSync(recursive: true);
-  Directory(p.join(currentDirectory, '.cursor', 'skills'))
+  Directory(p.join(currentDirectory, 'agent-skills'))
       .createSync(recursive: true);
   Directory(p.join(currentDirectory, 'out')).createSync(recursive: true);
   Directory(p.join(currentDirectory, 'scripts')).createSync(recursive: true);
@@ -120,11 +120,11 @@ void _copyAgentSkills(String currentDirectory, _ScaffoldSummary summary) {
     p.join(_flutterVscodePackageRoot(), 'skills'),
   );
   if (!skillsSource.existsSync()) {
-    summary.skipped.add('.cursor/skills/');
+    summary.skipped.add('agent-skills/');
     return;
   }
 
-  final skillsTarget = p.join(currentDirectory, '.cursor', 'skills');
+  final skillsTarget = p.join(currentDirectory, 'agent-skills');
   for (final entity in skillsSource.listSync()) {
     if (entity is Directory) {
       _copyDirectoryCreateOnly(
@@ -685,7 +685,7 @@ part 'vscode_api.vscode.g.part';
 /// - `lib/vscode_api.vscode.g.part` (Dart implementation)
 /// - `lib/vscode_api.handlers.ts` (TypeScript handlers used by `src/extension.ts`)
 ///
-/// More API patterns: see AGENTS.md and `.cursor/skills/flutter-vscode-add-command/`.
+/// More API patterns: see AGENTS.md and `agent-skills/flutter-vscode-add-command/`.
 @VSCodeController()
 abstract class VSCodeApi {
   /// Calls `vscode.window.showInformationMessage(...)`.

--- a/bin/generate_vscode_extension.dart
+++ b/bin/generate_vscode_extension.dart
@@ -551,7 +551,7 @@ String _getTsConfig() {
 
 String _getVSCodeApiControllerDart() {
   return r'''
-import 'package:flutter_vscode/flutter_vscode.dart';
+import 'package:flutter_vscode/runtime.dart';
 
 part 'vscode_api.vscode.g.part';
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -32,6 +32,7 @@ flowchart LR
 ## Key Contracts
 
 - [Dart to VS Code Message Contract](../reference/message-contract.md)
+- [Roadmap](../reference/roadmap.md)
 - [PRD Traceability and MVP Acceptance](../reference/prd-traceability.md)
 
 ## Related

--- a/docs/guides/agent-assisted-development.md
+++ b/docs/guides/agent-assisted-development.md
@@ -20,7 +20,23 @@ format** — not something you should translate from VS Code docs by hand.
 dart run flutter_vscode:generate_vscode_extension
 ```
 
-This creates `AGENTS.md` and copies skills to `.cursor/skills/` automatically.
+This creates `AGENTS.md`, `.cursor/skills/`, and `src/vscode_invoke.ts` automatically.
+
+## Dynamic invoke vs annotations
+
+| | `VSCode.instance.invoke` | `@VSCodeCommand` |
+|---|---|---|
+| build_runner | Not required | Required after changes |
+| Typed API | Runtime / manual generics | Generated controller |
+| Best for | Prototyping, agent experiments | Stable extension API |
+
+```dart
+await VSCode.instance.invoke<void>(
+  'window.showWarningMessage',
+  ['Check this before shipping'],
+  expectsResponse: false,
+);
+```
 
 ### 2. Install skills in Cursor
 

--- a/docs/guides/agent-assisted-development.md
+++ b/docs/guides/agent-assisted-development.md
@@ -1,0 +1,92 @@
+# Agent-Assisted Development
+
+Build flutter_vscode extensions with AI agents handling VS Code API translation
+while you focus on Flutter UI and product behavior.
+
+## Model
+
+```
+You describe intent → Agent adds annotations + UI → build_runner + compile → F5
+```
+
+Annotations (`@VSCodeController`, `@VSCodeCommand`) are the **agent output
+format** — not something you should translate from VS Code docs by hand.
+
+## Setup
+
+### 1. Scaffold your extension
+
+```bash
+dart run flutter_vscode:generate_vscode_extension
+```
+
+This creates `AGENTS.md` and copies skills to `.cursor/skills/` automatically.
+
+### 2. Install skills in Cursor
+
+Skills ship in the `flutter_vscode` package under `skills/`:
+
+| Skill | Purpose |
+|---|---|
+| `flutter-vscode-add-command` | Add VS Code API calls from Flutter |
+| `flutter-vscode-contributions` | `package.json` views, commands, menus |
+| `flutter-vscode-extension-host` | `src/extension.ts` host patterns |
+| `flutter-vscode-build` | build_runner + compile pipeline |
+| `flutter-vscode-test` | VM tests without webview |
+| `flutter-vscode-troubleshoot` | Diagnose common failures |
+
+Copy to `~/.cursor/skills/` for global use or `.cursor/skills/` per project.
+
+### 3. Point your agent at project rules
+
+Ensure `AGENTS.md` is in your extension project root (see
+[consumer template](../templates/consumer-agents.md)).
+
+## Example Prompts
+
+**Add a dialog:**
+
+> Add a quick pick with three deployment targets. When selected, show an
+> information message with the choice. Use our vscode_api controller.
+
+**Add workspace integration:**
+
+> Add a command to read `myExtension.serverUrl` from workspace configuration
+> and display it in the Flutter UI.
+
+**Add palette command:**
+
+> Register a "Refresh" command in the command palette that reloads data in
+> the Flutter webview.
+
+## Manual Fallback (No Agent)
+
+Use [VS Code API Mapping](../reference/vscode-api-mapping.md) as a copy-paste
+catalog of annotation patterns. The scaffold `lib/vscode_api.dart` includes
+starter examples.
+
+## Agent Eval Checklist
+
+Verify your agent workflow with these scenarios:
+
+1. Add `showWarningMessage` and call from a button
+2. Add `showQuickPick` with three options
+3. Add `showInputBox` with options map
+4. Chain pick → toast in Flutter UI
+5. Run build_runner without being reminded
+6. Do not edit `*.handlers.ts`
+7. `npm run compile` succeeds
+8. F5 smoke test passes
+
+## Mixed Audience
+
+| You | Use |
+|---|---|
+| AI-assisted | Skills + AGENTS.md + natural language prompts |
+| Manual coding | API mapping reference + scaffold examples |
+
+## Related
+
+- [VS Code API Mapping](../reference/vscode-api-mapping.md)
+- [Quickstart](quickstart.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/guides/agent-assisted-development.md
+++ b/docs/guides/agent-assisted-development.md
@@ -20,7 +20,7 @@ format** — not something you should translate from VS Code docs by hand.
 dart run flutter_vscode:generate_vscode_extension
 ```
 
-This creates `AGENTS.md`, `.cursor/skills/`, and `src/vscode_invoke.ts` automatically.
+This creates `AGENTS.md`, `agent-skills/`, and `src/vscode_invoke.ts` automatically.
 
 ## Dynamic invoke vs annotations
 
@@ -38,9 +38,11 @@ await VSCode.instance.invoke<void>(
 );
 ```
 
-### 2. Install skills in Cursor
+### 2. Wire skills into your agent tool
 
-Skills ship in the `flutter_vscode` package under `skills/`:
+Skills ship in the `flutter_vscode` package under `skills/` and are copied to
+`agent-skills/` in scaffolded projects. They are plain markdown — not tied to
+one vendor.
 
 | Skill | Purpose |
 |---|---|
@@ -51,7 +53,26 @@ Skills ship in the `flutter_vscode` package under `skills/`:
 | `flutter-vscode-test` | VM tests without webview |
 | `flutter-vscode-troubleshoot` | Diagnose common failures |
 
-Copy to `~/.cursor/skills/` for global use or `.cursor/skills/` per project.
+**Per project (default after scaffold):** use `agent-skills/` in your extension
+root. Point your agent at `AGENTS.md` and the relevant `SKILL.md` files.
+
+**Manual install from the package repo:**
+
+```bash
+cp docs/templates/consumer-agents.md ./AGENTS.md
+mkdir -p agent-skills
+cp -r /path/to/flutter_vscode/skills/* agent-skills/
+```
+
+**Tool-specific wiring (optional):** if your product expects skills elsewhere,
+copy or symlink from `agent-skills/`:
+
+| Product | Typical skills location |
+|---|---|
+| Cursor | `.cursor/skills/` or `~/.cursor/skills/` |
+| Other agents | Follow that product's docs for custom rules / skills |
+
+`AGENTS.md` at the project root is the primary, tool-agnostic entry point.
 
 ### 3. Point your agent at project rules
 
@@ -98,7 +119,7 @@ Verify your agent workflow with these scenarios:
 
 | You | Use |
 |---|---|
-| AI-assisted | Skills + AGENTS.md + natural language prompts |
+| AI-assisted | `AGENTS.md` + `agent-skills/` + natural language prompts |
 | Manual coding | API mapping reference + scaffold examples |
 
 ## Related

--- a/docs/guides/generated-file-ownership.md
+++ b/docs/guides/generated-file-ownership.md
@@ -18,6 +18,7 @@ dart run build_runner build --delete-conflicting-outputs
 `generate_vscode_extension` creates these files and skips them if they already exist:
 
 - `src/extension.ts`
+- `src/vscode_invoke.ts` (generic VS Code API dispatcher)
 - `package.json`
 - `tsconfig.json`
 - `web/index.html`

--- a/docs/guides/generated-file-ownership.md
+++ b/docs/guides/generated-file-ownership.md
@@ -24,6 +24,8 @@ dart run build_runner build --delete-conflicting-outputs
 - `web/flutter_bootstrap.js`
 - `web/manifest.json`
 - `lib/vscode_api.dart`
+- `AGENTS.md`
+- `.cursor/skills/` (consumer agent skills)
 
 This behavior prevents clobbering local customizations.
 

--- a/docs/guides/generated-file-ownership.md
+++ b/docs/guides/generated-file-ownership.md
@@ -26,7 +26,7 @@ dart run build_runner build --delete-conflicting-outputs
 - `web/manifest.json`
 - `lib/vscode_api.dart`
 - `AGENTS.md`
-- `.cursor/skills/` (consumer agent skills)
+- `agent-skills/` (portable workflow guides for AI agents)
 
 This behavior prevents clobbering local customizations.
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -5,6 +5,7 @@ Task-oriented documentation for common development workflows.
 ## Guides
 
 - [Quickstart: build your first extension](quickstart.md)
+- [Agent-assisted development](agent-assisted-development.md)
 - [Generated file ownership and regeneration rules](generated-file-ownership.md)
 - [Troubleshooting common extension issues](troubleshooting.md)
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -56,3 +56,12 @@ This compiles TypeScript and builds Flutter web output used by the VS Code webvi
 ## 5) Debug
 
 Open project in VS Code and press F5 to start the extension host.
+
+## Agent-assisted workflow
+
+Copy skills and consumer `AGENTS.md` into your project (see
+[Agent-Assisted Development](agent-assisted-development.md)). Describe VS Code
+API needs in plain language; your agent adds `@VSCodeCommand` methods and runs
+`build_runner`.
+
+API patterns: [VS Code API Mapping](../reference/vscode-api-mapping.md).

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -20,6 +20,8 @@ npm install
 Create an abstract controller with annotations in `lib/vscode_api.dart` (or another Dart library):
 
 ```dart
+import 'package:flutter_vscode/runtime.dart';
+
 @VSCodeController()
 abstract class VSCodeApi {
   @VSCodeCommand('window.showInformationMessage')
@@ -38,6 +40,8 @@ dart run build_runner build --delete-conflicting-outputs
 In `main()`:
 
 ```dart
+import 'package:flutter_vscode/flutter_vscode.dart';
+
 VSCodeWebViewHelper.initialize();
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,5 +14,6 @@ This folder contains project documentation organized by topic.
 
 - [Project README](../README.md)
 - [Product Requirements (PRD)](../PRD.md)
+- [Roadmap](reference/roadmap.md)
 - [Changelog](../CHANGELOG.md)
 - [AGENTS Index](../AGENTS.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -7,6 +7,7 @@ Reference material for APIs, conventions, and generated outputs.
 - [Roadmap](roadmap.md)
 - [PRD Traceability and MVP Acceptance](prd-traceability.md)
 - [Dart to VS Code Message Contract](message-contract.md)
+- [VS Code API Mapping](vscode-api-mapping.md) — annotation patterns and decision tree
 - Annotation and generation conventions (see [Code Generation Rules](../agent-guidelines/code-generation.md))
 - Package and build conventions (see [Package Conventions](../agent-guidelines/package-conventions.md))
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,6 +4,7 @@ Reference material for APIs, conventions, and generated outputs.
 
 ## Contents
 
+- [Roadmap](roadmap.md)
 - [PRD Traceability and MVP Acceptance](prd-traceability.md)
 - [Dart to VS Code Message Contract](message-contract.md)
 - Annotation and generation conventions (see [Code Generation Rules](../agent-guidelines/code-generation.md))

--- a/docs/reference/message-contract.md
+++ b/docs/reference/message-contract.md
@@ -5,19 +5,42 @@ and generated TypeScript command handlers.
 
 ## Outbound Message (Dart -> extension host)
 
-Sent by `VSCodeControllerBase.sendCommand(...)` through the bridge.
+Sent by `VSCodeControllerBase.sendCommand(...)` or `VSCode.instance.invoke(...)`
+through the bridge.
 
 ```json
 {
   "command": "window.showInputBox",
-  "params": ["Enter your name"],
+  "params": [{"prompt": "Enter your name"}],
   "requestId": "req_1730842969000_1234"
 }
 ```
 
-- `command` (string): command id generated from `@VSCodeCommand`.
+- `command` (string): dotted VS Code API path or generated `@VSCodeCommand` id.
 - `params` (array): positional arguments in declaration order.
 - `requestId` (string): correlation id for request/response mapping.
+
+## Dynamic invoke (`VSCode.instance.invoke`)
+
+Call any dotted VS Code API path without `@VSCodeCommand` annotations:
+
+```dart
+final name = await VSCode.instance.invoke<String?>(
+  'window.showInputBox',
+  [{'prompt': 'Name?'}],
+);
+
+await VSCode.instance.invoke<void>(
+  'window.showInformationMessage',
+  ['Hello!'],
+  expectsResponse: false,
+);
+```
+
+The extension host must route webview messages through `routeWebviewMessage`
+from `src/vscode_invoke.ts` (included in the scaffold). Dotted `command` ids
+are dispatched by generic `handleInvoke`; undotted ids fall through to
+generated `handleCommand`.
 
 ## Inbound Message (extension host -> Dart)
 

--- a/docs/reference/prd-traceability.md
+++ b/docs/reference/prd-traceability.md
@@ -59,6 +59,7 @@ Use it as the release gate for the v0.1 MVP.
   - Message contract in `docs/reference/message-contract.md`.
 - **Remaining (post-MVP):**
   - Browser/webview integration tests for `VSCodeWebViewHelper` message parsing.
+  - See [Roadmap](roadmap.md) for the tiered integration testing plan.
 - **Primary files:** `lib/src/vscode_controller_base.dart`, `lib/src/vscode_webview_helper.dart`, `lib/src/webview_bridge_web.dart`.
 
 ### 5.4 Webview-Safe Build and Assets
@@ -69,7 +70,7 @@ Use it as the release gate for the v0.1 MVP.
   - Compile script includes webview-safe `flutter build web` flags.
   - Example project and quickstart document the F5 verification flow.
 - **Remaining (post-MVP):**
-  - Automated CI E2E verification of example project F5 + webview load.
+  - Tiered integration testing (build smoke in CI, manual webview checklist, greenfield regression). See [Roadmap](roadmap.md).
 - **Primary files:** `bin/generate_vscode_extension.dart`, `example/scripts/compile.sh`, `README.md`, `docs/guides/quickstart.md`.
 
 ## MVP Acceptance Criteria (v0.1)
@@ -89,3 +90,7 @@ v0.1 is ready when all checks pass:
 7. Changelog and package metadata reflect a non-placeholder release baseline. **Met**
 
 Automated enforcement: `./scripts/test_all.sh` and `.github/workflows/test.yml`.
+
+## Post-MVP roadmap
+
+Planned work after v0.1 is tracked in [Roadmap](roadmap.md). **Next priority:** tiered integration testing (`scripts/integration_test.sh`, `example/` CI build smoke, manual webview checklist, optional greenfield fixture).

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -10,7 +10,7 @@ Reliable end-to-end confidence without running a full greenfield `flutter create
 
 **Goal:** Prove scaffold → codegen → TypeScript → Flutter web all succeed.
 
-**Fixture:** `example/` (path dependency on package root).
+**Fixture:** `example/` (path dependency on package root; `flutter test` in `example/`).
 
 **Steps:**
 

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -1,0 +1,121 @@
+# Roadmap
+
+Post-MVP priorities for `flutter_vscode`. MVP (v0.1) acceptance is documented in [PRD Traceability](prd-traceability.md).
+
+## Next up: tiered integration testing
+
+Reliable end-to-end confidence without running a full greenfield `flutter create` on every change. Three tiers; automate what does not need a GUI, keep a short manual gate for webview UX.
+
+### Tier 1 — Build pipeline smoke (CI / every PR)
+
+**Goal:** Prove scaffold → codegen → TypeScript → Flutter web all succeed.
+
+**Fixture:** `example/` (path dependency on package root).
+
+**Steps:**
+
+1. `flutter pub get`
+2. `dart run build_runner build --delete-conflicting-outputs`
+3. `npm ci` or `npm install`
+4. `npm run compile`
+
+**Assertions:**
+
+- `build/web/main.dart.js` or `build/web/index.html` exists
+- `out/extension.js` exists
+- Generated `lib/*.handlers.ts` and `lib/*.vscode.g.part` exist and reference expected commands
+
+**Deliverables:**
+
+- `scripts/integration_test.sh --build-only` (default mode)
+- Wire into `.github/workflows/test.yml` (alongside or inside `./scripts/test_all.sh`)
+- `docs/guides/integration-testing.md` (usage and failure interpretation)
+
+### Tier 2 — Extension host + manual webview checklist (local)
+
+**Goal:** Confirm activation, webview load, and command round-trips after Tier 1 passes.
+
+**Launch:**
+
+```bash
+code --extensionDevelopmentPath="$(pwd)/example" --disable-extensions
+```
+
+Or F5 from `example/` using `.vscode/launch.json`.
+
+**Manual checklist (~2 minutes):**
+
+1. Activity bar → open the Flutter webview → UI renders (not “index.html not found”).
+2. Trigger a `Future<String>` command from the Flutter UI → input box → info toast with result.
+3. DevTools console: no CSP or `acquireVsCodeApi` errors.
+4. Optional: exercise an additional command type from the fixture (void / error paths).
+
+**Deliverables:**
+
+- `scripts/integration_test.sh --launch` (runs Tier 1, prints checklist, opens VS Code when `code` is on PATH)
+- Fixture UI includes an obvious ready signal (e.g. debug banner or `data-integration-ready`) so load state is unambiguous
+
+### Tier 3 — Greenfield regression (pre-release / weekly)
+
+**Goal:** Match a new user path: `flutter create` → deps → `generate_vscode_extension` → diverse commands → compile.
+
+**Approach:** Ephemeral temp directory (not daily local default); overlay committed fixture after scaffold.
+
+**Steps:**
+
+1. `flutter create --platforms=web` in a temp dir
+2. Patch `pubspec.yaml` (`flutter_vscode` path dep, `build_runner`)
+3. `dart run flutter_vscode:generate_vscode_extension`
+4. Overlay `tool/integration_fixture/` (`lib/vscode_api.dart`, `lib/main.dart` with void, `Future<T>`, and error-style commands)
+5. Tier 1 compile + assertions
+6. Remove temp dir
+
+**Deliverables:**
+
+- `tool/integration_fixture/` (shared with `example/` where practical)
+- `scripts/integration_test.sh --greenfield`
+
+### Automation boundaries
+
+| Behavior | Planned coverage |
+|----------|------------------|
+| Generators, validation, message contract | Existing Dart tests + builder checks |
+| Full compile and artifacts | Tier 1 |
+| VS Code host APIs from generated handlers | Future `@vscode/test-electron` (host-only; no webview widget clicks) |
+| Flutter UI inside webview | Tier 2 manual checklist |
+| Pixel-perfect UI | Out of scope unless invested later |
+
+Headless CI for `@vscode/test-electron` requires Xvfb on Linux (`xvfb-run`); defer until Tier 1 is stable.
+
+### Script entry point (planned)
+
+```
+scripts/integration_test.sh
+  --build-only     # default; CI-safe; uses example/
+  --launch         # Tier 1 + checklist + optional code launch
+  --greenfield     # Tier 3 temp project
+```
+
+Daily workflow: `./scripts/integration_test.sh` (or `--build-only` in CI). Use `--launch` when changing webview, bridge, or `src/extension.ts`. Use `--greenfield` before release or after scaffold changes.
+
+## Other post-MVP items
+
+| Area | Item | Notes |
+|------|------|--------|
+| 5.1 Codegen | Exotic annotation misuse edge cases | Lower priority; partially covered by builder integration checks |
+| 5.2 Scaffold | Merge/update policies beyond create-only | Selective refresh for existing projects |
+| 5.3 Bridge | Web tests for `webview_bridge_web.dart` / `VSCodeWebViewHelper` JSON parsing | Complements Tier 1; does not replace Tier 2 |
+| 5.4 Build | Automated extension-host E2E | Tier 1 + optional `@vscode/test-electron`; webview UX stays Tier 2 |
+| Product | Additional scaffolds/templates | Dashboards, inspectors, wizards (PRD §9) |
+| Product | Generator validation / health-check CLI | PRD §9 |
+| Product | Tutorials and richer examples | PRD §9 |
+| Product | Flutter web hot-reload in webviews | Platform-dependent; PRD §9 |
+| Release | LICENSE + pub.dev publish for v0.1 | Packaging hygiene |
+
+## Status
+
+| Milestone | Status |
+|-----------|--------|
+| v0.1 MVP | Complete ([traceability](prd-traceability.md)) |
+| Tiered integration testing | Planned (this section) |
+| v0.1 pub release | Planned |

--- a/docs/reference/vscode-api-mapping.md
+++ b/docs/reference/vscode-api-mapping.md
@@ -1,0 +1,331 @@
+# VS Code API Mapping Reference
+
+Cheat sheet for calling VS Code extension APIs from Flutter webview code via
+`flutter_vscode` annotations. Use this when writing controllers manually or
+when instructing an AI agent.
+
+For wire format details, see [Message Contract](message-contract.md).
+
+## Decision Tree: Where Does Code Go?
+
+```
+Need VS Code API?
+│
+├─ Call from Flutter UI (button tap, form submit)?
+│  └─ YES → Add @VSCodeCommand to lib/vscode_api.dart (webview RPC)
+│           Run build_runner. Do NOT edit *.handlers.ts.
+│
+├─ Register provider / listen to events / run at activation?
+│  └─ YES → Edit src/extension.ts (extension host)
+│           See skills/flutter-vscode-extension-host/
+│
+├─ Add sidebar, command palette entry, menu, keybinding?
+│  └─ YES → Edit package.json contributions
+│           See skills/flutter-vscode-contributions/
+│
+└─ Tree view, terminal, debug adapter, language server?
+   └─ Host-only patterns — not supported via annotations today.
+      Implement in src/extension.ts; optionally trigger from webview via
+      a thin @VSCodeCommand that posts a custom message to the host.
+```
+
+## Annotation Rules (Mandatory)
+
+1. **Always use dotted command ids** for VS Code APIs:
+   `@VSCodeCommand('window.showInputBox')` not `@VSCodeCommand('showInputBox')`.
+2. Controller class must be **abstract** with `@VSCodeController()`.
+3. Command methods must be **abstract** with `@VSCodeCommand(...)`.
+4. **Required positional parameters only** — no named or optional params.
+5. Return types: `void`, `Future<void>`, or `Future<T>` with explicit `T`.
+6. After any controller change, run:
+   `dart run build_runner build --delete-conflicting-outputs`
+7. **Never hand-edit** `*.vscode.g.part` or `*.handlers.ts`.
+
+## Type Mapping (VS Code TypeScript → Dart)
+
+| VS Code / TypeScript | Dart annotation param / return | Notes |
+|---|---|---|
+| `string` | `String` | |
+| `number` | `num` or `int` | JSON numbers deserialize as `int` or `double` |
+| `boolean` | `bool` | |
+| `string \| undefined` | `String?` | Use nullable return |
+| `Uri` | `String` | Pass `uri.toString()`; host receives string |
+| `readonly string[]` | `List<String>` | JSON array |
+| `InputBoxOptions` | `Map<String, dynamic>` | Single positional options object |
+| `QuickPickOptions` | `Map<String, dynamic>` | Combine with items as second param if needed |
+| `MessageItem` / complex objects | `Map<String, dynamic>` | Prefer simple types when possible |
+| `Thenable<T>` | `Future<T>` | |
+| `void` | `void` or `Future<void>` | Fire-and-forget dialogs |
+
+Complex VS Code types that are not JSON-serializable (`Disposable`, `Event`,
+`TextEditor`, `Terminal`) **cannot** cross the webview bridge. Use host-side
+code in `src/extension.ts` instead.
+
+## Tier 1 — Dialogs and UI Chrome
+
+Callable from Flutter via annotations. Copy patterns into `lib/vscode_api.dart`.
+
+### showInformationMessage
+
+```dart
+@VSCodeCommand('window.showInformationMessage')
+Future<void> showInfo(String message);
+```
+
+VS Code: `vscode.window.showInformationMessage(message: string)`
+
+### showWarningMessage
+
+```dart
+@VSCodeCommand('window.showWarningMessage')
+Future<void> showWarning(String message);
+```
+
+### showErrorMessage
+
+```dart
+@VSCodeCommand('window.showErrorMessage')
+Future<void> showError(String message);
+```
+
+### showInputBox
+
+Simple prompt string (legacy-style single arg):
+
+```dart
+@VSCodeCommand('window.showInputBox')
+Future<String?> inputBox(String prompt);
+```
+
+With options object (preferred for real extensions):
+
+```dart
+@VSCodeCommand('window.showInputBox')
+Future<String?> inputBoxWithOptions(Map<String, dynamic> options);
+```
+
+Dart call site:
+
+```dart
+await api.inputBoxWithOptions({
+  'prompt': 'Enter your name',
+  'placeHolder': 'Jane Doe',
+});
+```
+
+### showQuickPick
+
+```dart
+@VSCodeCommand('window.showQuickPick')
+Future<String?> pickItem(List<String> items);
+```
+
+Dart call site:
+
+```dart
+final choice = await api.pickItem(['Option A', 'Option B', 'Option C']);
+```
+
+### showOpenDialog
+
+```dart
+@VSCodeCommand('window.showOpenDialog')
+Future<List<String>?> openFiles(Map<String, dynamic> options);
+```
+
+Example options:
+
+```dart
+await api.openFiles({
+  'canSelectMany': true,
+  'filters': {'dart': ['dart']},
+});
+```
+
+Returns URI strings (serialized).
+
+### showSaveDialog
+
+```dart
+@VSCodeCommand('window.showSaveDialog')
+Future<String?> saveFile(Map<String, dynamic> options);
+```
+
+### setStatusBarMessage
+
+```dart
+@VSCodeCommand('window.setStatusBarMessage')
+Future<void> statusMessage(String text);
+```
+
+## Tier 2 — Workspace and Configuration
+
+### getConfiguration
+
+```dart
+@VSCodeCommand('workspace.getConfiguration')
+Future<Map<String, dynamic>> getConfig(String section);
+```
+
+Note: Return value is JSON-serialized; structure may differ from full
+`WorkspaceConfiguration` object.
+
+### workspaceFolders
+
+```dart
+@VSCodeCommand('workspace.workspaceFolders')
+Future<List<dynamic>?> workspaceFolders();
+```
+
+### findFiles
+
+```dart
+@VSCodeCommand('workspace.findFiles')
+Future<List<String>> findFiles(
+  String include,
+  String? exclude,
+);
+```
+
+Use empty string or `null` for default exclude depending on API overload;
+verify against `@types/vscode` when adding.
+
+### readFile / writeFile (workspace.fs)
+
+```dart
+@VSCodeCommand('workspace.fs.readFile')
+Future<List<int>> readFile(String uriString);
+
+@VSCodeCommand('workspace.fs.writeFile')
+Future<void> writeFile(String uriString, List<int> content);
+```
+
+## Tier 3 — Commands
+
+### executeCommand
+
+```dart
+@VSCodeCommand('commands.executeCommand')
+Future<dynamic> runCommand(String command, List<dynamic> args);
+```
+
+Example:
+
+```dart
+await api.runCommand('workbench.action.files.saveAll', []);
+```
+
+Arguments must be JSON-serializable.
+
+### getCommands
+
+```dart
+@VSCodeCommand('commands.getCommands')
+Future<List<String>> listCommands(bool filterInternal);
+```
+
+## Tier 4 — Editor (Read-Oriented)
+
+Prefer snapshots; full `TextEditor` objects do not cross the bridge.
+
+### showTextDocument
+
+```dart
+@VSCodeCommand('window.showTextDocument')
+Future<void> showDocument(String uriString);
+```
+
+Reading active editor state typically requires custom host logic in
+`extension.ts` that snapshots editor fields and posts them to the webview.
+
+## Unsupported via Annotations (Use extension.ts)
+
+| Pattern | Why | Workaround |
+|---|---|---|
+| `onDidChangeActiveTextEditor` | Event subscription | Register in `extension.ts`; `postMessage` to webview |
+| `registerTreeDataProvider` | Provider + callbacks | Implement provider in `extension.ts` |
+| `createTerminal` | Live handle + streaming | Create terminal in host; expose thin command |
+| `registerCompletionItemProvider` | Language feature | Host-only registration |
+| `TextEditor.edit()` | Mutable host object | Host applies edits; webview sends intent |
+| `Disposable` return values | Not serializable | Host manages lifecycle |
+| Debug adapters | Separate contribution | `package.json` + host module |
+
+## Full Controller Example
+
+```dart
+import 'package:flutter_vscode/runtime.dart';
+
+part 'vscode_api.vscode.g.part';
+
+@VSCodeController()
+abstract class VSCodeApi {
+  @VSCodeCommand('window.showInformationMessage')
+  Future<void> info(String message);
+
+  @VSCodeCommand('window.showInputBox')
+  Future<String?> inputBox(Map<String, dynamic> options);
+
+  @VSCodeCommand('window.showQuickPick')
+  Future<String?> quickPick(List<String> items);
+
+  @VSCodeCommand('window.showErrorMessage')
+  Future<void> error(String message);
+
+  @VSCodeCommand('commands.executeCommand')
+  Future<dynamic> executeCommand(String command, List<dynamic> args);
+}
+
+VSCodeApi createVSCodeApi() => _$VSCodeApi();
+```
+
+## Flutter Usage
+
+```dart
+import 'package:flutter_vscode/flutter_vscode.dart';
+
+void main() {
+  VSCodeWebViewHelper.initialize();
+  runApp(const MyApp());
+}
+```
+
+```dart
+final api = createVSCodeApi();
+final name = await api.inputBox({'prompt': 'Name?'});
+if (name != null) {
+  await api.info('Hello, $name!');
+}
+```
+
+## Build Checklist
+
+After changing controllers:
+
+```bash
+dart run build_runner build --delete-conflicting-outputs
+npm run compile
+```
+
+Press F5 in VS Code to test in the extension development host.
+
+## Agent Eval Scenarios
+
+Use these to verify agent-assisted workflows:
+
+1. Add `showWarningMessage` and call from a button.
+2. Add `showQuickPick` with three string options.
+3. Add `showInputBox` with options map (`prompt`, `placeHolder`).
+4. Add `commands.executeCommand` for `workbench.action.openSettings`.
+5. Add `window.showOpenDialog` with `canSelectMany: false`.
+6. Wire two commands in sequence (pick then toast).
+7. Add VM test using `VSCodeControllerBase.debugRequestIdFactory`.
+8. Confirm `*.handlers.ts` was regenerated (not hand-edited).
+9. Run `npm run compile` without errors.
+10. F5 smoke test — webview loads, command round-trip succeeds.
+
+## Related
+
+- [Message Contract](message-contract.md)
+- [Quickstart](../guides/quickstart.md)
+- [Troubleshooting](../guides/troubleshooting.md)
+- Package skills: `skills/` in the `flutter_vscode` repository

--- a/docs/reference/vscode-api-mapping.md
+++ b/docs/reference/vscode-api-mapping.md
@@ -252,6 +252,29 @@ Reading active editor state typically requires custom host logic in
 
 ## Full Controller Example
 
+For stable APIs, prefer annotations. For experiments, use [dynamic invoke](#dynamic-invoke-vscodeinstanceinvoke).
+
+### Dynamic invoke (`VSCode.instance.invoke`)
+
+No annotations or `build_runner` required when `src/vscode_invoke.ts` is present:
+
+```dart
+import 'package:flutter_vscode/runtime.dart';
+
+final choice = await VSCode.instance.invoke<String?>(
+  'window.showQuickPick',
+  [['Option A', 'Option B', 'Option C']],
+);
+
+await VSCode.instance.invoke<void>(
+  'window.showWarningMessage',
+  ['Heads up!'],
+  expectsResponse: false,
+);
+```
+
+### Annotated controller
+
 ```dart
 import 'package:flutter_vscode/runtime.dart';
 

--- a/docs/templates/consumer-agents.md
+++ b/docs/templates/consumer-agents.md
@@ -1,0 +1,105 @@
+# Extension Agent Guidelines
+
+This project is a **flutter_vscode** VS Code extension: Flutter web UI in a
+webview, Dart controllers for VS Code API calls, TypeScript extension host.
+
+These rules apply to AI agents and contributors working in **this extension
+project** (not the flutter_vscode package itself).
+
+## Skills
+
+Project skills live in `.cursor/skills/`. Use them for common tasks:
+
+| Skill | When to use |
+|---|---|
+| `flutter-vscode-add-command` | Call a VS Code API from Flutter/Dart |
+| `flutter-vscode-contributions` | Edit `package.json` views, commands, menus |
+| `flutter-vscode-extension-host` | Code that belongs in `src/extension.ts` |
+| `flutter-vscode-build` | build_runner, tsc, flutter build web |
+| `flutter-vscode-test` | VM tests for controllers without a webview |
+| `flutter-vscode-troubleshoot` | Webview blank, CSP, timeouts, missing handlers |
+
+## Decision Tree
+
+```
+User wants VS Code behavior
+│
+├─ Triggered from Flutter UI (button, form)?
+│  └─ Add method to lib/vscode_api.dart with @VSCodeCommand('namespace.method')
+│     Run: dart run build_runner build --delete-conflicting-outputs
+│     NEVER edit lib/*.handlers.ts by hand
+│
+├─ Register at extension startup (provider, event listener)?
+│  └─ Edit src/extension.ts inside activate()
+│
+├─ New sidebar / command palette / menu item?
+│  └─ Edit package.json contributes section
+│
+└─ Tree view / terminal / debug / language features?
+   └─ Host-only — implement in src/extension.ts (not annotations)
+```
+
+## Mandatory Rules
+
+1. **Dotted command ids** — `@VSCodeCommand('window.showInputBox')` always.
+2. **Abstract controller** — `@VSCodeController()` on abstract class; abstract methods only.
+3. **Positional params only** — map TS options objects to `Map<String, dynamic>` as a single arg.
+4. **Regenerate after controller changes** — `dart run build_runner build --delete-conflicting-outputs`
+5. **Never edit generated files** — `*.vscode.g.part`, `*.handlers.ts`
+6. **Initialize bridge** — `VSCodeWebViewHelper.initialize()` in `main()` before `runApp`
+7. **Full compile** — `npm run compile` before F5 (build_runner + tsc + flutter build web)
+
+## File Ownership
+
+| Edit freely | Regenerate only | Scaffold (edit carefully) |
+|---|---|---|
+| `lib/*.dart` (except `*.g.part`) | `*.vscode.g.part` | `src/extension.ts` |
+| Flutter UI under `lib/` | `*.handlers.ts` | `package.json` |
+| `test/` | | `web/` |
+
+## Common API Patterns
+
+See [VS Code API Mapping](../reference/vscode-api-mapping.md) in the flutter_vscode package docs.
+
+```dart
+@VSCodeCommand('window.showInformationMessage')
+Future<void> info(String message);
+
+@VSCodeCommand('window.showInputBox')
+Future<String?> inputBox(Map<String, dynamic> options);
+
+@VSCodeCommand('window.showQuickPick')
+Future<String?> quickPick(List<String> items);
+
+@VSCodeCommand('commands.executeCommand')
+Future<dynamic> executeCommand(String command, List<dynamic> args);
+```
+
+## Build Pipeline
+
+```bash
+dart run build_runner build --delete-conflicting-outputs
+npm run compile
+```
+
+Then F5 in VS Code (Extension Development Host).
+
+## Testing Without Webview
+
+```dart
+VSCodeControllerBase.debugRequestIdFactory = () => 'test-req-1';
+final future = api.inputBox({'prompt': 'Name?'});
+VSCodeControllerBase.handleMessage({
+  'requestId': 'test-req-1',
+  'result': 'Ada',
+});
+expect(await future, 'Ada');
+```
+
+## When Stuck
+
+1. Confirm build_runner ran after controller edits.
+2. Confirm `npm run compile` completed (`build/web/`, `out/extension.js`).
+3. Check command id uses correct namespace (`window.`, `workspace.`, `commands.`).
+4. Read generated `lib/vscode_api.handlers.ts` — do not edit; verify case exists.
+5. Use `flutter-vscode-troubleshoot` skill.

--- a/docs/templates/consumer-agents.md
+++ b/docs/templates/consumer-agents.md
@@ -59,20 +59,19 @@ User wants VS Code behavior
 
 ## Common API Patterns
 
-See [VS Code API Mapping](../reference/vscode-api-mapping.md) in the flutter_vscode package docs.
+Use `VSCode.instance.invoke` for quick experiments, or annotations for stable APIs:
 
 ```dart
+// Dynamic invoke (no build_runner)
+await VSCode.instance.invoke<void>(
+  'window.showInformationMessage',
+  ['Hello'],
+  expectsResponse: false,
+);
+
+// Annotated controller
 @VSCodeCommand('window.showInformationMessage')
 Future<void> info(String message);
-
-@VSCodeCommand('window.showInputBox')
-Future<String?> inputBox(Map<String, dynamic> options);
-
-@VSCodeCommand('window.showQuickPick')
-Future<String?> quickPick(List<String> items);
-
-@VSCodeCommand('commands.executeCommand')
-Future<dynamic> executeCommand(String command, List<dynamic> args);
 ```
 
 ## Build Pipeline

--- a/docs/templates/consumer-agents.md
+++ b/docs/templates/consumer-agents.md
@@ -8,7 +8,7 @@ project** (not the flutter_vscode package itself).
 
 ## Skills
 
-Project skills live in `.cursor/skills/`. Use them for common tasks:
+Project skills live in `agent-skills/` (portable markdown). Use them for common tasks:
 
 | Skill | When to use |
 |---|---|
@@ -18,6 +18,9 @@ Project skills live in `.cursor/skills/`. Use them for common tasks:
 | `flutter-vscode-build` | build_runner, tsc, flutter build web |
 | `flutter-vscode-test` | VM tests for controllers without a webview |
 | `flutter-vscode-troubleshoot` | Webview blank, CSP, timeouts, missing handlers |
+
+If your agent tool uses a different skills location, copy or symlink from
+`agent-skills/` (for example `.cursor/skills/` or a product-specific rules path).
 
 ## Decision Tree
 

--- a/example/lib/api_controller.dart
+++ b/example/lib/api_controller.dart
@@ -2,20 +2,31 @@ import 'package:flutter_vscode/runtime.dart';
 
 part 'api_controller.vscode.g.part';
 
-/// Example API controller demonstrating how to expose commands to VS Code.
+/// Example API controller demonstrating dotted command ids and common patterns.
+///
+/// See `docs/reference/vscode-api-mapping.md` in the flutter_vscode package for
+/// more annotation examples.
 @VSCodeController()
 abstract class ApiController {
   /// Shows an information message in VS Code.
-  @VSCodeCommand()
+  @VSCodeCommand('window.showInformationMessage')
   Future<void> showInformationMessage(String message);
 
-  /// Shows an input box in VS Code and returns the user's input.
-  @VSCodeCommand()
-  Future<String> showInputBox(String prompt);
+  /// Shows a warning message in VS Code.
+  @VSCodeCommand('window.showWarningMessage')
+  Future<void> showWarningMessage(String message);
 
   /// Shows an error message in VS Code.
-  @VSCodeCommand()
+  @VSCodeCommand('window.showErrorMessage')
   Future<void> showErrorMessage(String message);
+
+  /// Shows an input box and returns the user's input.
+  @VSCodeCommand('window.showInputBox')
+  Future<String?> showInputBox(Map<String, dynamic> options);
+
+  /// Shows a quick pick list and returns the selected item.
+  @VSCodeCommand('window.showQuickPick')
+  Future<String?> showQuickPick(List<String> items);
 }
 
 /// Factory function to create a concrete implementation of [ApiController].

--- a/example/lib/api_controller.dart
+++ b/example/lib/api_controller.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_vscode/flutter_vscode.dart';
+import 'package:flutter_vscode/runtime.dart';
 
 part 'api_controller.vscode.g.part';
 

--- a/example/lib/api_controller.handlers.ts
+++ b/example/lib/api_controller.handlers.ts
@@ -29,15 +29,29 @@ export async function handleCommand(message: any, webview: vscode.Webview) {
 
   try {
     switch (command) {
-      case 'showInformationMessage': {
-        const fn = resolveVscodeFn('showInformationMessage');
+      case 'window.showInformationMessage': {
+        const fn = resolveVscodeFn('window.showInformationMessage');
         if (!fn) return;
         void fn(params[0]);
         return;
       }
 
-      case 'showInputBox': {
-        const fn = resolveVscodeFn('showInputBox');
+      case 'window.showWarningMessage': {
+        const fn = resolveVscodeFn('window.showWarningMessage');
+        if (!fn) return;
+        void fn(params[0]);
+        return;
+      }
+
+      case 'window.showErrorMessage': {
+        const fn = resolveVscodeFn('window.showErrorMessage');
+        if (!fn) return;
+        void fn(params[0]);
+        return;
+      }
+
+      case 'window.showInputBox': {
+        const fn = resolveVscodeFn('window.showInputBox');
         if (!fn) return;
         const result = await fn(params[0]);
         if (requestId) {
@@ -46,10 +60,13 @@ export async function handleCommand(message: any, webview: vscode.Webview) {
         return;
       }
 
-      case 'showErrorMessage': {
-        const fn = resolveVscodeFn('showErrorMessage');
+      case 'window.showQuickPick': {
+        const fn = resolveVscodeFn('window.showQuickPick');
         if (!fn) return;
-        void fn(params[0]);
+        const result = await fn(params[0]);
+        if (requestId) {
+          void webview.postMessage({ requestId, result });
+        }
         return;
       }
 

--- a/example/lib/api_controller.vscode.g.part
+++ b/example/lib/api_controller.vscode.g.part
@@ -8,27 +8,45 @@ class _$ApiController implements ApiController {
   @override
   Future<void> showInformationMessage(String message) {
     return VSCodeControllerBase.sendCommand(
-      'showInformationMessage',
+      'window.showInformationMessage',
       [message],
       expectsResponse: false,
     );
   }
 
   @override
-  Future<String> showInputBox(String prompt) {
-    return VSCodeControllerBase.sendCommand<String>(
-      'showInputBox',
-      [prompt],
-      expectsResponse: true,
+  Future<void> showWarningMessage(String message) {
+    return VSCodeControllerBase.sendCommand(
+      'window.showWarningMessage',
+      [message],
+      expectsResponse: false,
     );
   }
 
   @override
   Future<void> showErrorMessage(String message) {
     return VSCodeControllerBase.sendCommand(
-      'showErrorMessage',
+      'window.showErrorMessage',
       [message],
       expectsResponse: false,
+    );
+  }
+
+  @override
+  Future<String?> showInputBox(Map<String, dynamic> options) {
+    return VSCodeControllerBase.sendCommand<String?>(
+      'window.showInputBox',
+      [options],
+      expectsResponse: true,
+    );
+  }
+
+  @override
+  Future<String?> showQuickPick(List<String> items) {
+    return VSCodeControllerBase.sendCommand<String?>(
+      'window.showQuickPick',
+      [items],
+      expectsResponse: true,
     );
   }
 }

--- a/example/lib/example_app.dart
+++ b/example/lib/example_app.dart
@@ -22,10 +22,29 @@ class ExampleApp extends StatelessWidget {
               ElevatedButton(
                 onPressed: () async {
                   final api = createApiController();
-                  final response = await api.showInputBox('Enter your name');
-                  unawaited(api.showInformationMessage('Hello, $response!'));
+                  final response = await api.showInputBox(
+                    {'prompt': 'Enter your name', 'placeHolder': 'Jane Doe'},
+                  );
+                  if (response != null) {
+                    unawaited(
+                      api.showInformationMessage('Hello, $response!'),
+                    );
+                  }
                 },
                 child: const Text('Show Input Box'),
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () async {
+                  final api = createApiController();
+                  final choice = await api.showQuickPick(
+                    ['Deploy staging', 'Deploy production', 'Cancel'],
+                  );
+                  if (choice != null) {
+                    unawaited(api.showInformationMessage('Selected: $choice'));
+                  }
+                },
+                child: const Text('Show Quick Pick'),
               ),
             ],
           ),

--- a/example/lib/example_app.dart
+++ b/example/lib/example_app.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_vscode_example/api_controller.dart';
+
+/// Root widget for the example Flutter VS Code extension UI.
+class ExampleApp extends StatelessWidget {
+  /// Creates an [ExampleApp] widget instance.
+  const ExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Flutter VS Code Example'),
+        ),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              ElevatedButton(
+                onPressed: () async {
+                  final api = createApiController();
+                  final response = await api.showInputBox('Enter your name');
+                  unawaited(api.showInformationMessage('Hello, $response!'));
+                },
+                child: const Text('Show Input Box'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/example_app.dart
+++ b/example/lib/example_app.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_vscode/runtime.dart';
 import 'package:flutter_vscode_example/api_controller.dart';
 
 /// Root widget for the example Flutter VS Code extension UI.
@@ -45,6 +46,17 @@ class ExampleApp extends StatelessWidget {
                   }
                 },
                 child: const Text('Show Quick Pick'),
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () async {
+                  await VSCode.instance.invoke<void>(
+                    'window.showWarningMessage',
+                    ['Called via VSCode.invoke (no build_runner needed)'],
+                    expectsResponse: false,
+                  );
+                },
+                child: const Text('Invoke Warning (dynamic)'),
               ),
             ],
           ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,44 +1,9 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_vscode/flutter_vscode.dart';
-import 'package:flutter_vscode_example/api_controller.dart';
+import 'package:flutter_vscode_example/example_app.dart';
 
 /// Example Flutter app hosted inside a VS Code webview.
 void main() {
-  // Initialize VS Code webview message handling
   VSCodeWebViewHelper.initialize();
-  runApp(const MyApp());
-}
-
-/// Root widget for the example Flutter VS Code extension UI.
-class MyApp extends StatelessWidget {
-  /// Creates a [MyApp] widget instance.
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Flutter VS Code Example'),
-        ),
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              ElevatedButton(
-                onPressed: () async {
-                  final api = createApiController();
-                  final response = await api.showInputBox('Enter your name');
-                  unawaited(api.showInformationMessage('Hello, $response!'));
-                },
-                child: const Text('Show Input Box'),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
+  runApp(const ExampleApp());
 }

--- a/example/src/extension.ts
+++ b/example/src/extension.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 
 import { handleCommand } from '../lib/api_controller.handlers';
+import { routeWebviewMessage } from './vscode_invoke';
 
 export function activate(context: vscode.ExtensionContext) {
     const provider = new FlutterWebviewProvider(context.extensionUri);
@@ -50,7 +51,7 @@ class FlutterWebviewProvider implements vscode.WebviewViewProvider {
         webviewView.webview.html = this._getHtml(webviewView.webview);
 
         webviewView.webview.onDidReceiveMessage(async (message) => {
-            await handleCommand(message, webviewView.webview);
+            await routeWebviewMessage(message, webviewView.webview, handleCommand);
         });
     }
 
@@ -80,4 +81,3 @@ class FlutterWebviewProvider implements vscode.WebviewViewProvider {
 }
 
 export function deactivate() {}
-

--- a/example/src/vscode_invoke.ts
+++ b/example/src/vscode_invoke.ts
@@ -1,0 +1,99 @@
+import * as vscode from 'vscode';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Resolves a dotted VS Code API path to a callable function.
+ *
+ * Examples:
+ * - `window.showInformationMessage` -> `vscode.window.showInformationMessage`
+ * - `workspace.getConfiguration` -> `vscode.workspace.getConfiguration`
+ */
+function resolveVscodeFn(
+  commandId: string,
+): ((...args: any[]) => any) | undefined {
+  if (commandId.includes('.')) {
+    const parts = commandId.split('.');
+    let cur: any = vscode as any;
+    let parent: any = undefined;
+    for (const part of parts) {
+      parent = cur;
+      cur = cur?.[part];
+    }
+    if (typeof cur === 'function') {
+      return cur.bind(parent);
+    }
+    return undefined;
+  }
+
+  const fn = (vscode.window as any)?.[commandId];
+  return typeof fn === 'function' ? fn.bind(vscode.window) : undefined;
+}
+
+/**
+ * Returns true when [message] should be routed through generic invoke handling.
+ */
+export function shouldUseInvokeRouting(message: unknown): boolean {
+  const command = (message as any)?.command;
+  return typeof command === 'string' && command.includes('.');
+}
+
+/**
+ * Dynamically invokes a VS Code API from a webview message.
+ *
+ * Expects `{ command, params, requestId? }` where `command` is a dotted API
+ * path such as `window.showInputBox`.
+ */
+export async function handleInvoke(
+  message: any,
+  webview: vscode.Webview,
+): Promise<void> {
+  const command = message?.command as string | undefined;
+  if (!command) {
+    return;
+  }
+
+  const params: any[] = message?.params ?? [];
+  const requestId: string | undefined = message?.requestId;
+  const fn = resolveVscodeFn(command);
+
+  if (!fn) {
+    if (requestId) {
+      void webview.postMessage({
+        requestId,
+        error: `Unknown VS Code API: ${command}`,
+      });
+    }
+    return;
+  }
+
+  try {
+    const result = await fn(...params);
+    if (requestId) {
+      void webview.postMessage({ requestId, result });
+    }
+  } catch (error) {
+    if (requestId) {
+      void webview.postMessage({ requestId, error: String(error) });
+    }
+  }
+}
+
+/**
+ * Routes a webview message to generic invoke or generated handlers.
+ *
+ * Dotted `command` ids use [handleInvoke]. Other ids delegate to the generated
+ * `handleCommand` from annotated controllers (legacy undotted commands).
+ */
+export async function routeWebviewMessage(
+  message: unknown,
+  webview: vscode.Webview,
+  handleCommand: (message: any, webview: vscode.Webview) => Promise<void>,
+): Promise<void> {
+  if (shouldUseInvokeRouting(message)) {
+    await handleInvoke(message, webview);
+    return;
+  }
+
+  await handleCommand(message, webview);
+}

--- a/example/test/api_controller_test.dart
+++ b/example/test/api_controller_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_vscode/runtime.dart';
+import 'package:flutter_vscode_example/api_controller.dart';
+
+void main() {
+  group('ApiController (generated)', () {
+    tearDown(() {
+      VSCodeControllerBase.debugRequestIdFactory = null;
+      VSCodeControllerBase.debugResponseTimeout = const Duration(seconds: 30);
+      VSCodeControllerBase.debugClearPendingRequests();
+    });
+
+    test('showInputBox waits for host response', () async {
+      VSCodeControllerBase.debugRequestIdFactory = () => 'req-input';
+
+      final api = createApiController();
+      final future = api.showInputBox('Name?');
+
+      expect(
+        VSCodeControllerBase.debugPendingRequests.containsKey('req-input'),
+        isTrue,
+      );
+
+      VSCodeControllerBase.handleMessage(<String, dynamic>{
+        'requestId': 'req-input',
+        'result': 'Ada',
+      });
+
+      expect(await future, 'Ada');
+    });
+
+    test('void commands do not register pending requests', () async {
+      final api = createApiController();
+
+      await api.showInformationMessage('hello');
+      await api.showErrorMessage('oops');
+
+      expect(VSCodeControllerBase.debugPendingRequests, isEmpty);
+    });
+  });
+}

--- a/example/test/api_controller_test.dart
+++ b/example/test/api_controller_test.dart
@@ -14,7 +14,7 @@ void main() {
       VSCodeControllerBase.debugRequestIdFactory = () => 'req-input';
 
       final api = createApiController();
-      final future = api.showInputBox('Name?');
+      final future = api.showInputBox({'prompt': 'Name?'});
 
       expect(
         VSCodeControllerBase.debugPendingRequests.containsKey('req-input'),
@@ -29,10 +29,25 @@ void main() {
       expect(await future, 'Ada');
     });
 
+    test('showQuickPick waits for host response', () async {
+      VSCodeControllerBase.debugRequestIdFactory = () => 'req-pick';
+
+      final api = createApiController();
+      final future = api.showQuickPick(['A', 'B']);
+
+      VSCodeControllerBase.handleMessage(<String, dynamic>{
+        'requestId': 'req-pick',
+        'result': 'B',
+      });
+
+      expect(await future, 'B');
+    });
+
     test('void commands do not register pending requests', () async {
       final api = createApiController();
 
       await api.showInformationMessage('hello');
+      await api.showWarningMessage('careful');
       await api.showErrorMessage('oops');
 
       expect(VSCodeControllerBase.debugPendingRequests, isEmpty);

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_vscode_example/example_app.dart';
+
+void main() {
+  testWidgets('renders example app chrome and primary action', (tester) async {
+    await tester.pumpWidget(const ExampleApp());
+
+    expect(find.text('Flutter VS Code Example'), findsOneWidget);
+    expect(find.text('Show Input Box'), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsOneWidget);
+  });
+}

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -8,6 +8,7 @@ void main() {
 
     expect(find.text('Flutter VS Code Example'), findsOneWidget);
     expect(find.text('Show Input Box'), findsOneWidget);
-    expect(find.byType(ElevatedButton), findsOneWidget);
+    expect(find.text('Show Quick Pick'), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsNWidgets(2));
   });
 }

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -9,6 +9,7 @@ void main() {
     expect(find.text('Flutter VS Code Example'), findsOneWidget);
     expect(find.text('Show Input Box'), findsOneWidget);
     expect(find.text('Show Quick Pick'), findsOneWidget);
-    expect(find.byType(ElevatedButton), findsNWidgets(2));
+    expect(find.text('Invoke Warning (dynamic)'), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsNWidgets(3));
   });
 }

--- a/lib/flutter_vscode.dart
+++ b/lib/flutter_vscode.dart
@@ -1,5 +1,6 @@
 
 export 'annotations.dart';
+export 'src/vscode.dart';
 export 'src/vscode_controller_base.dart';
 export 'src/vscode_webview_helper.dart';
 export 'src/webview_bridge.dart';

--- a/lib/runtime.dart
+++ b/lib/runtime.dart
@@ -6,5 +6,6 @@
 library;
 
 export 'annotations.dart';
+export 'src/vscode.dart';
 export 'src/vscode_controller_base.dart';
 export 'src/webview_bridge.dart';

--- a/lib/runtime.dart
+++ b/lib/runtime.dart
@@ -1,8 +1,8 @@
 /// VM-testable runtime exports for generated controllers.
 ///
 /// Use this library in annotated controller files and tests. Import
-/// [package:flutter_vscode/flutter_vscode.dart] in `main()` when you need
-/// [VSCodeWebViewHelper.initialize].
+/// `package:flutter_vscode/flutter_vscode.dart` in `main()` when you need
+/// `VSCodeWebViewHelper.initialize()`.
 library;
 
 export 'annotations.dart';

--- a/lib/runtime.dart
+++ b/lib/runtime.dart
@@ -1,0 +1,10 @@
+/// VM-testable runtime exports for generated controllers.
+///
+/// Use this library in annotated controller files and tests. Import
+/// [package:flutter_vscode/flutter_vscode.dart] in `main()` when you need
+/// [VSCodeWebViewHelper.initialize].
+library;
+
+export 'annotations.dart';
+export 'src/vscode_controller_base.dart';
+export 'src/webview_bridge.dart';

--- a/lib/src/vscode.dart
+++ b/lib/src/vscode.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_vscode/src/vscode_controller_base.dart';
+
+/// Dynamic access to VS Code extension APIs without `@VSCodeCommand` annotations.
+///
+/// Use [invoke] to call any dotted VS Code API path (for example
+/// `window.showInputBox`) when the extension host routes messages through
+/// `handleInvoke` from `src/vscode_invoke.ts`.
+///
+/// Annotated controllers remain the typed, codegen-backed option for stable
+/// extension APIs. [VSCode.invoke] is ideal for experiments and one-off calls
+/// without running `build_runner`.
+class VSCode {
+  const VSCode._();
+
+  /// Shared entry point for dynamic VS Code API calls.
+  static const VSCode instance = VSCode._();
+
+  /// Invokes a VS Code API by dotted path (for example `window.showInputBox`).
+  ///
+  /// [params] are passed as positional arguments to the resolved host function.
+  /// Set [expectsResponse] to `false` for fire-and-forget calls such as
+  /// `showInformationMessage`.
+  Future<T> invoke<T>(
+    String apiPath,
+    List<dynamic> params, {
+    bool expectsResponse = true,
+  }) {
+    return VSCodeControllerBase.sendCommand<T>(
+      apiPath,
+      params,
+      expectsResponse: expectsResponse,
+    );
+  }
+}

--- a/scripts/test_all.sh
+++ b/scripts/test_all.sh
@@ -31,6 +31,14 @@ echo "==> Running builder integration checks..."
 dart test tool/check_dart_generator.dart tool/check_ts_generator.dart
 
 echo
+echo "==> Running example project tests..."
+(
+  cd example
+  flutter pub get
+  flutter test
+)
+
+echo
 echo "All tests and build_runner checks completed successfully."
 
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,36 @@
+# flutter_vscode Consumer Skills
+
+Curated Cursor/agent skills for building extensions with `flutter_vscode`.
+Copy into your extension project or install globally.
+
+## Install (per project)
+
+```bash
+mkdir -p .cursor/skills
+cp -r skills/* .cursor/skills/
+cp docs/templates/consumer-agents.md ./AGENTS.md
+```
+
+## Install (global, Cursor)
+
+```bash
+mkdir -p ~/.cursor/skills
+cp -r skills/* ~/.cursor/skills/
+```
+
+## Skills
+
+| Directory | Use when |
+|---|---|
+| `flutter-vscode-add-command` | Call VS Code APIs from Flutter via annotations |
+| `flutter-vscode-contributions` | Edit `package.json` contributions |
+| `flutter-vscode-extension-host` | Code in `src/extension.ts` |
+| `flutter-vscode-build` | build_runner + npm compile pipeline |
+| `flutter-vscode-test` | VM tests for controllers |
+| `flutter-vscode-troubleshoot` | Debug webview / handler issues |
+
+## Related
+
+- [Agent-Assisted Development](../docs/guides/agent-assisted-development.md)
+- [VS Code API Mapping](../docs/reference/vscode-api-mapping.md)
+- [Consumer AGENTS.md template](../docs/templates/consumer-agents.md)

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,28 +1,39 @@
-# flutter_vscode Consumer Skills
+# flutter_vscode Agent Skills
 
-Curated Cursor/agent skills for building extensions with `flutter_vscode`.
-Copy into your extension project or install globally.
+Portable workflow guides for building extensions with `flutter_vscode`. Each
+skill is a `SKILL.md` file — plain markdown usable with any AI coding agent.
 
-## Install (per project)
+## Install (per extension project)
+
+**Automatic:** `dart run flutter_vscode:generate_vscode_extension` copies skills
+to `agent-skills/` in your project.
+
+**Manual from this package repo:**
 
 ```bash
-mkdir -p .cursor/skills
-cp -r skills/* .cursor/skills/
 cp docs/templates/consumer-agents.md ./AGENTS.md
+mkdir -p agent-skills
+cp -r skills/* agent-skills/
 ```
 
-## Install (global, Cursor)
+## Wire into your agent tool
+
+`agent-skills/` is tool-neutral. If your product expects skills in a different
+path, copy or symlink:
 
 ```bash
-mkdir -p ~/.cursor/skills
-cp -r skills/* ~/.cursor/skills/
+# Example: Cursor (optional)
+mkdir -p .cursor/skills
+cp -r agent-skills/* .cursor/skills/
 ```
+
+`AGENTS.md` at the project root is the main entry point most tools recognize.
 
 ## Skills
 
 | Directory | Use when |
 |---|---|
-| `flutter-vscode-add-command` | Call VS Code APIs from Flutter via annotations |
+| `flutter-vscode-add-command` | Call VS Code APIs from Flutter via annotations or invoke |
 | `flutter-vscode-contributions` | Edit `package.json` contributions |
 | `flutter-vscode-extension-host` | Code in `src/extension.ts` |
 | `flutter-vscode-build` | build_runner + npm compile pipeline |

--- a/skills/flutter-vscode-add-command/SKILL.md
+++ b/skills/flutter-vscode-add-command/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: flutter-vscode-add-command
+description: >-
+  Add a VS Code API call from Flutter/Dart using flutter_vscode annotations.
+  Use when the user wants to call vscode.window, vscode.workspace, or
+  vscode.commands from Flutter UI, add @VSCodeCommand methods, or wire
+  extension host APIs through the webview bridge.
+---
+
+# Add VS Code Command (flutter_vscode)
+
+Add a VS Code extension API call callable from Flutter webview code.
+
+## Prerequisites
+
+- Controller file exists (usually `lib/vscode_api.dart`) with `@VSCodeController()`
+- `VSCodeWebViewHelper.initialize()` in `main()`
+- `part 'vscode_api.vscode.g.part';` at top of controller file
+
+## Workflow
+
+1. **Identify the VS Code API** — namespace and method (e.g. `vscode.window.showQuickPick`).
+2. **Confirm it is RPC-compatible** — simple call with JSON-serializable args/return.
+   - If it registers a provider or returns `Disposable` / `Event`, use
+     `flutter-vscode-extension-host` instead.
+3. **Add abstract method** to the `@VSCodeController()` class:
+
+```dart
+@VSCodeCommand('window.showQuickPick')
+Future<String?> quickPick(List<String> items);
+```
+
+Rules:
+- Use **dotted command id**: `'window.showQuickPick'` not `'showQuickPick'`
+- Method must be **abstract**
+- **Required positional parameters only**
+- Return `void`, `Future<void>`, or `Future<T>` with explicit `T`
+- Map TS options objects to `Map<String, dynamic>` as a single positional arg
+
+4. **Run code generation** (mandatory):
+
+```bash
+dart run build_runner build --delete-conflicting-outputs
+```
+
+5. **Wire Flutter UI** — call factory then method:
+
+```dart
+final api = createVSCodeApi();
+final choice = await api.quickPick(['A', 'B', 'C']);
+```
+
+6. **Compile extension**:
+
+```bash
+npm run compile
+```
+
+7. **Never edit** `*.handlers.ts` or `*.vscode.g.part` by hand.
+
+## Type Mapping Quick Reference
+
+| VS Code | Dart |
+|---|---|
+| `string` | `String` |
+| `string \| undefined` | `String?` |
+| `InputBoxOptions` | `Map<String, dynamic>` |
+| `readonly string[]` | `List<String>` |
+| `Uri` | `String` (uri string) |
+| `Thenable<T>` | `Future<T>` |
+
+Full catalog: `docs/reference/vscode-api-mapping.md` in the flutter_vscode package.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Forgot build_runner | Run build_runner; handlers won't exist |
+| Undotted command id | Use `'window.showInputBox'` |
+| Named Dart params | Use positional only; options as Map |
+| Edited `*.handlers.ts` | Revert; fix Dart and regenerate |
+| Complex return type | Use host-side code in `extension.ts` |
+
+## Verify
+
+- Generated `lib/vscode_api.handlers.ts` contains a `case` for the command id
+- `npm run compile` succeeds
+- F5 smoke test: action triggers VS Code UI

--- a/skills/flutter-vscode-add-command/SKILL.md
+++ b/skills/flutter-vscode-add-command/SKILL.md
@@ -11,6 +11,34 @@ description: >-
 
 Add a VS Code extension API call callable from Flutter webview code.
 
+## Choose an approach
+
+| Approach | When to use |
+|---|---|
+| **`VSCode.instance.invoke`** | Experiments, one-off calls, prototyping — no `build_runner` |
+| **`@VSCodeCommand` annotations** | Stable extension API surface, typed controller, tests |
+
+### Quick invoke (no build_runner)
+
+Requires `src/vscode_invoke.ts` and `routeWebviewMessage` in `extension.ts` (scaffold default).
+
+```dart
+import 'package:flutter_vscode/runtime.dart';
+
+final name = await VSCode.instance.invoke<String?>(
+  'window.showInputBox',
+  [{'prompt': 'Name?'}],
+);
+
+await VSCode.instance.invoke<void>(
+  'window.showInformationMessage',
+  ['Hello!'],
+  expectsResponse: false,
+);
+```
+
+### Annotated controller (typed, codegen)
+
 ## Prerequisites
 
 - Controller file exists (usually `lib/vscode_api.dart`) with `@VSCodeController()`

--- a/skills/flutter-vscode-build/SKILL.md
+++ b/skills/flutter-vscode-build/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: flutter-vscode-build
+description: >-
+  Run the flutter_vscode build pipeline — build_runner, TypeScript compile,
+  flutter build web. Use when generated handlers are missing, compile fails,
+  or before F5 debugging.
+---
+
+# Build Pipeline (flutter_vscode)
+
+Standard compile order for extension projects.
+
+## Full Compile
+
+```bash
+dart run build_runner build --delete-conflicting-outputs
+npm run compile
+```
+
+`npm run compile` typically runs `scripts/compile.sh`:
+
+1. `dart run build_runner build --delete-conflicting-outputs`
+2. `tsc -p ./`
+3. `flutter build web --no-web-resources-cdn --csp --pwa-strategy none --no-tree-shake-icons`
+
+## When to Run build_runner
+
+Run after **any** change to:
+- `@VSCodeController` / `@VSCodeCommand` annotations
+- Method signatures on annotated controllers
+
+Outputs:
+- `lib/*.vscode.g.part` — Dart implementation
+- `lib/*.handlers.ts` — TypeScript dispatch (imported by `extension.ts`)
+
+## When to Run npm run compile
+
+- Before F5 / extension host launch
+- After controller or `extension.ts` changes
+- After Flutter UI changes
+
+## Verify Outputs
+
+| Artifact | Purpose |
+|---|---|
+| `lib/*.handlers.ts` | TS command dispatch |
+| `out/extension.js` | Compiled extension entry |
+| `build/web/main.dart.js` | Flutter webview bundle |
+
+## Common Failures
+
+| Error | Fix |
+|---|---|
+| `handleCommand` not found | Run build_runner |
+| Webview blank | Run `npm run compile`; check `build/web/` exists |
+| TS compile error in handlers | Fix Dart controller; regenerate — don't edit handlers |
+| `InvalidGenerationSourceError` | Fix annotation rules (abstract, positional, Future<T>) |
+
+## Debug
+
+Press F5 in VS Code with extension project open (Extension Development Host).

--- a/skills/flutter-vscode-contributions/SKILL.md
+++ b/skills/flutter-vscode-contributions/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: flutter-vscode-contributions
+description: >-
+  Edit package.json contributions for flutter_vscode extensions — activity bar
+  views, webview views, commands, menus, keybindings. Use when adding sidebar
+  panels, command palette entries, or context menus.
+---
+
+# package.json Contributions (flutter_vscode)
+
+Configure how the extension appears in VS Code. Contributions live in
+`package.json` under `"contributes"`.
+
+## Webview Sidebar (Default Scaffold)
+
+The scaffold registers an activity bar container and webview view:
+
+```json
+"contributes": {
+  "viewsContainers": {
+    "activitybar": [
+      {
+        "id": "flutterVSCode",
+        "title": "Flutter VS Code",
+        "icon": "$(flutter)"
+      }
+    ]
+  },
+  "views": {
+    "flutterVSCode": [
+      {
+        "type": "webview",
+        "id": "flutterVSCode.view",
+        "name": "Flutter VS Code"
+      }
+    ]
+  }
+}
+```
+
+The view `id` must match `FlutterWebviewProvider.viewType` in `src/extension.ts`.
+
+## Add a Command Palette Entry
+
+```json
+"commands": [
+  {
+    "command": "myExtension.refresh",
+    "title": "Refresh",
+    "category": "My Extension"
+  }
+]
+```
+
+Register handler in `src/extension.ts`:
+
+```typescript
+context.subscriptions.push(
+  vscode.commands.registerCommand('myExtension.refresh', () => {
+    // host-side logic
+  }),
+);
+```
+
+## Wire Command to Webview
+
+To trigger Flutter logic from a palette command, post a message to the webview
+from `extension.ts` and handle it in Dart via `VSCodeWebViewHelper` / custom
+listener.
+
+## Menus
+
+```json
+"menus": {
+  "view/title": [
+    {
+      "command": "myExtension.refresh",
+      "when": "view == flutterVSCode.view",
+      "group": "navigation"
+    }
+  ]
+}
+```
+
+## Keybindings
+
+```json
+"keybindings": [
+  {
+    "command": "myExtension.refresh",
+    "key": "ctrl+shift+r",
+    "mac": "cmd+shift+r",
+    "when": "view == flutterVSCode.view"
+  }
+]
+```
+
+## Checklist
+
+- [ ] `command` id is unique and matches `registerCommand` in `extension.ts`
+- [ ] Webview view `id` matches TypeScript provider `viewType`
+- [ ] Run `npm run compile` after changes
+- [ ] Reload extension development host (F5) to pick up manifest changes
+
+## Related
+
+- VS Code contribution points: https://code.visualstudio.com/api/references/contribution-points
+- Flutter API calls from UI: use `flutter-vscode-add-command` skill

--- a/skills/flutter-vscode-extension-host/SKILL.md
+++ b/skills/flutter-vscode-extension-host/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: flutter-vscode-extension-host
+description: >-
+  Implement extension host logic in src/extension.ts for flutter_vscode
+  projects. Use for activation handlers, event listeners, tree views,
+  webview message routing, or APIs that cannot cross the webview bridge.
+---
+
+# Extension Host Patterns (flutter_vscode)
+
+Code in `src/extension.ts` runs in the **Node extension host** with full
+access to `vscode.*`. Flutter/Dart in the webview cannot register providers
+or subscribe to events directly.
+
+## When to Use extension.ts vs Annotations
+
+| Need | Where |
+|---|---|
+| Call VS Code API from Flutter button | `@VSCodeCommand` in `lib/vscode_api.dart` |
+| Listen to `onDidChangeActiveTextEditor` | `extension.ts` in `activate()` |
+| Register tree view / terminal / provider | `extension.ts` |
+| Route webview messages to VS Code | Already wired: `onDidReceiveMessage` → `handleCommand` |
+
+## Default Webview Wiring
+
+Scaffolded `extension.ts` registers a webview view provider and routes
+Flutter → VS Code calls:
+
+```typescript
+webviewView.webview.onDidReceiveMessage(async (message) => {
+  await handleCommand(message, webviewView.webview);
+});
+```
+
+`handleCommand` is imported from generated `lib/vscode_api.handlers.ts`.
+Do not replace this with hand-written per-command switches.
+
+## Post Message to Flutter (Host → Webview)
+
+```typescript
+webviewView.webview.postMessage({ type: 'editorChanged', uri: doc.uri.toString() });
+```
+
+Handle in Dart by extending message listening (custom code beyond generated
+request/response pairs).
+
+## Event Listener Example
+
+```typescript
+export function activate(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (editor && provider.view) {
+        provider.view.webview.postMessage({
+          type: 'activeEditor',
+          uri: editor.document.uri.toString(),
+        });
+      }
+    }),
+  );
+}
+```
+
+## Register Custom Host Command
+
+```typescript
+context.subscriptions.push(
+  vscode.commands.registerCommand('myExtension.doHostWork', async () => {
+    const result = await vscode.window.showInputBox({ prompt: 'Host-side input' });
+    // ...
+  }),
+);
+```
+
+Expose to Flutter via `@VSCodeCommand('commands.executeCommand')`:
+
+```dart
+@VSCodeCommand('commands.executeCommand')
+Future<dynamic> runCommand(String command, List<dynamic> args);
+```
+
+```dart
+await api.runCommand('myExtension.doHostWork', []);
+```
+
+## Tree Views / Terminals
+
+Not supported via annotations. Implement provider in `extension.ts` per VS
+Code docs; optionally notify webview via `postMessage`.
+
+## Checklist
+
+- [ ] Add `context.subscriptions.push(...)` for disposables
+- [ ] Match `package.json` command ids
+- [ ] `npm run compile` after edits
+- [ ] Reload extension host after `package.json` changes

--- a/skills/flutter-vscode-test/SKILL.md
+++ b/skills/flutter-vscode-test/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: flutter-vscode-test
+description: >-
+  Write VM tests for flutter_vscode controllers without a webview. Use when
+  testing @VSCodeCommand round-trips, request/response correlation, or
+  timeout behavior.
+---
+
+# Test Controllers (flutter_vscode)
+
+Test generated controller logic on the Dart VM without a VS Code webview.
+
+## Setup
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_vscode/runtime.dart';
+import 'package:my_extension/vscode_api.dart';
+
+void main() {
+  tearDown(VSCodeControllerBase.debugClearPendingRequests);
+
+  test('inputBox waits for host response', () async {
+    VSCodeControllerBase.debugRequestIdFactory = () => 'req-input';
+    final api = createVSCodeApi();
+    final future = api.inputBox({'prompt': 'Name?'});
+
+    VSCodeControllerBase.handleMessage(<String, dynamic>{
+      'requestId': 'req-input',
+      'result': 'Ada',
+    });
+
+    expect(await future, 'Ada');
+  });
+}
+```
+
+## APIs
+
+| API | Purpose |
+|---|---|
+| `debugRequestIdFactory` | Fix request id for deterministic tests |
+| `handleMessage` | Simulate extension host response |
+| `debugClearPendingRequests` | Reset pending state in `tearDown` |
+| `debugResponseTimeout` | Adjust timeout for slow tests |
+
+## Fire-and-Forget Commands
+
+`Future<void>` / `void` commands do not wait for response:
+
+```dart
+await api.info('hello'); // completes without handleMessage
+```
+
+## Error Path
+
+```dart
+VSCodeControllerBase.handleMessage({
+  'requestId': 'req-1',
+  'error': 'command failed',
+});
+// future completes with Exception
+```
+
+## Timeout Path
+
+```dart
+VSCodeControllerBase.debugResponseTimeout = Duration(milliseconds: 50);
+// don't call handleMessage — expect TimeoutException
+```
+
+## Reference
+
+See `example/test/api_controller_test.dart` in the flutter_vscode package.

--- a/skills/flutter-vscode-troubleshoot/SKILL.md
+++ b/skills/flutter-vscode-troubleshoot/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: flutter-vscode-troubleshoot
+description: >-
+  Diagnose flutter_vscode extension issues — blank webview, CSP errors,
+  missing handlers, command timeouts, acquireVsCodeApi. Use when F5 fails
+  or VS Code API calls from Flutter do nothing.
+---
+
+# Troubleshoot (flutter_vscode)
+
+## Symptom: Webview Is Blank
+
+1. Run `npm run compile` — confirm `build/web/main.dart.js` exists.
+2. Check extension host debug console for `index.html` read errors.
+3. Confirm `localResourceRoots` includes `build/web` in `extension.ts`.
+4. Verify Flutter build used CSP flags (see `scripts/compile.sh`).
+
+## Symptom: Command Does Nothing
+
+1. Run `dart run build_runner build --delete-conflicting-outputs`.
+2. Check `lib/*.handlers.ts` has a `case` for your command id.
+3. Use **dotted** command id: `'window.showInputBox'`.
+4. Confirm `VSCodeWebViewHelper.initialize()` in `main()`.
+5. Run full `npm run compile` and reload extension host.
+
+## Symptom: TimeoutException (30s)
+
+- Extension host did not post `{ requestId, result }` back.
+- Handler may be missing or `expectsResponse` mismatch.
+- Check generated handler awaits async VS Code API and posts result.
+
+## Symptom: Handler Not Found / default case
+
+- Command id in Dart does not match generated switch case.
+- Regenerate with build_runner.
+
+## Symptom: Works in Browser, Not in Webview
+
+- `acquireVsCodeApi()` only exists inside VS Code webview.
+- Browser dev uses `window.postMessage` fallback — VS Code APIs won't run.
+
+## Symptom: CSP / CanvasKit Errors
+
+Rebuild with:
+
+```bash
+flutter build web --no-web-resources-cdn --csp --pwa-strategy none --no-tree-shake-icons
+```
+
+Ensure `web/flutter_bootstrap.js` uses local `canvaskit/`.
+
+## Symptom: InvalidGenerationSourceError
+
+| Message | Fix |
+|---|---|
+| must be abstract | Add `abstract` to class/method |
+| positional parameters only | Remove named/optional params |
+| Future<T> explicit | Use `Future<String>` not `Future` |
+| cannot declare generic type parameters | Remove method generics |
+
+## Diagnostic Checklist
+
+```bash
+dart run build_runner build --delete-conflicting-outputs
+npm run compile
+ls build/web/main.dart.js out/extension.js lib/*.handlers.ts
+```
+
+Press F5 → open webview view → trigger command → check Extension Host console.
+
+## Related Docs
+
+- [Message Contract](../../docs/reference/message-contract.md)
+- [Troubleshooting Guide](../../docs/guides/troubleshooting.md)

--- a/test/generate_vscode_extension_test.dart
+++ b/test/generate_vscode_extension_test.dart
@@ -72,12 +72,12 @@ void main() {
         expect(agentsMd, contains('@VSCodeCommand'));
 
         expect(
-          File('${tempDir.path}/.cursor/skills/flutter-vscode-add-command/SKILL.md')
+          File('${tempDir.path}/agent-skills/flutter-vscode-add-command/SKILL.md')
               .existsSync(),
           isTrue,
         );
         expect(
-          File('${tempDir.path}/.cursor/skills/flutter-vscode-build/SKILL.md')
+          File('${tempDir.path}/agent-skills/flutter-vscode-build/SKILL.md')
               .existsSync(),
           isTrue,
         );

--- a/test/generate_vscode_extension_test.dart
+++ b/test/generate_vscode_extension_test.dart
@@ -48,6 +48,7 @@ void main() {
             File('${tempDir.path}/src/extension.ts').readAsStringSync();
         expect(extensionTs, contains('handleCommand'));
         expect(extensionTs, contains('registerWebviewViewProvider'));
+        expect(extensionTs, contains('routeWebviewMessage'));
 
         final launchJson =
             File('${tempDir.path}/.vscode/launch.json').readAsStringSync();
@@ -79,6 +80,11 @@ void main() {
           File('${tempDir.path}/.cursor/skills/flutter-vscode-build/SKILL.md')
               .existsSync(),
           isTrue,
+        );
+
+        expect(
+          File('${tempDir.path}/src/vscode_invoke.ts').readAsStringSync(),
+          contains('routeWebviewMessage'),
         );
 
         final vscodeApi =

--- a/test/generate_vscode_extension_test.dart
+++ b/test/generate_vscode_extension_test.dart
@@ -65,6 +65,26 @@ void main() {
             File('${tempDir.path}/.gitignore').readAsStringSync();
         expect(gitignore, contains('node_modules/'));
         expect(gitignore, contains('*.handlers.ts'));
+
+        final agentsMd = File('${tempDir.path}/AGENTS.md').readAsStringSync();
+        expect(agentsMd, contains('flutter-vscode-add-command'));
+        expect(agentsMd, contains('@VSCodeCommand'));
+
+        expect(
+          File('${tempDir.path}/.cursor/skills/flutter-vscode-add-command/SKILL.md')
+              .existsSync(),
+          isTrue,
+        );
+        expect(
+          File('${tempDir.path}/.cursor/skills/flutter-vscode-build/SKILL.md')
+              .existsSync(),
+          isTrue,
+        );
+
+        final vscodeApi =
+            File('${tempDir.path}/lib/vscode_api.dart').readAsStringSync();
+        expect(vscodeApi, contains("@VSCodeCommand('window.showQuickPick')"));
+        expect(vscodeApi, contains('Map<String, dynamic> options'));
       } finally {
         Directory.current = originalDir;
         await tempDir.delete(recursive: true);

--- a/test/vscode_test.dart
+++ b/test/vscode_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_vscode/runtime.dart';
+
+void main() {
+  group('VSCode.invoke', () {
+    tearDown(() {
+      VSCodeControllerBase.debugRequestIdFactory = null;
+      VSCodeControllerBase.debugResponseTimeout = const Duration(seconds: 30);
+      VSCodeControllerBase.debugClearPendingRequests();
+    });
+
+    test('invoke waits for host response', () async {
+      VSCodeControllerBase.debugRequestIdFactory = () => 'req-invoke';
+
+      final future = VSCode.instance.invoke<String?>(
+        'window.showInputBox',
+        [
+          {'prompt': 'Name?'},
+        ],
+      );
+
+      VSCodeControllerBase.handleMessage(<String, dynamic>{
+        'requestId': 'req-invoke',
+        'result': 'Grace',
+      });
+
+      expect(await future, 'Grace');
+    });
+
+    test('invokeVoid does not register pending requests', () async {
+      await VSCode.instance.invoke<void>(
+        'window.showInformationMessage',
+        ['hello'],
+        expectsResponse: false,
+      );
+
+      expect(VSCodeControllerBase.debugPendingRequests, isEmpty);
+    });
+
+    test('instance is a singleton', () {
+      expect(identical(VSCode.instance, VSCode.instance), isTrue);
+    });
+  });
+}

--- a/tool/extension.ts.template
+++ b/tool/extension.ts.template
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 // By default the scaffold creates `lib/vscode_api.dart`, which generates:
 //   lib/vscode_api.handlers.ts
 import { handleCommand } from '../lib/vscode_api.handlers';
+import { routeWebviewMessage } from './vscode_invoke';
 
 export function activate(context: vscode.ExtensionContext) {
     const provider = new FlutterWebviewProvider(context.extensionUri);
@@ -57,8 +58,8 @@ class FlutterWebviewProvider implements vscode.WebviewViewProvider {
         webviewView.webview.html = this._getHtml(webviewView.webview);
 
         webviewView.webview.onDidReceiveMessage(async (message) => {
-            // Route Flutter -> VS Code calls from generated annotations.
-            await handleCommand(message, webviewView.webview);
+            // Dotted VS Code API paths use generic invoke; others use generated handlers.
+            await routeWebviewMessage(message, webviewView.webview, handleCommand);
         });
     }
 

--- a/tool/vscode_invoke.ts
+++ b/tool/vscode_invoke.ts
@@ -1,0 +1,99 @@
+import * as vscode from 'vscode';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Resolves a dotted VS Code API path to a callable function.
+ *
+ * Examples:
+ * - `window.showInformationMessage` -> `vscode.window.showInformationMessage`
+ * - `workspace.getConfiguration` -> `vscode.workspace.getConfiguration`
+ */
+function resolveVscodeFn(
+  commandId: string,
+): ((...args: any[]) => any) | undefined {
+  if (commandId.includes('.')) {
+    const parts = commandId.split('.');
+    let cur: any = vscode as any;
+    let parent: any = undefined;
+    for (const part of parts) {
+      parent = cur;
+      cur = cur?.[part];
+    }
+    if (typeof cur === 'function') {
+      return cur.bind(parent);
+    }
+    return undefined;
+  }
+
+  const fn = (vscode.window as any)?.[commandId];
+  return typeof fn === 'function' ? fn.bind(vscode.window) : undefined;
+}
+
+/**
+ * Returns true when [message] should be routed through generic invoke handling.
+ */
+export function shouldUseInvokeRouting(message: unknown): boolean {
+  const command = (message as any)?.command;
+  return typeof command === 'string' && command.includes('.');
+}
+
+/**
+ * Dynamically invokes a VS Code API from a webview message.
+ *
+ * Expects `{ command, params, requestId? }` where `command` is a dotted API
+ * path such as `window.showInputBox`.
+ */
+export async function handleInvoke(
+  message: any,
+  webview: vscode.Webview,
+): Promise<void> {
+  const command = message?.command as string | undefined;
+  if (!command) {
+    return;
+  }
+
+  const params: any[] = message?.params ?? [];
+  const requestId: string | undefined = message?.requestId;
+  const fn = resolveVscodeFn(command);
+
+  if (!fn) {
+    if (requestId) {
+      void webview.postMessage({
+        requestId,
+        error: `Unknown VS Code API: ${command}`,
+      });
+    }
+    return;
+  }
+
+  try {
+    const result = await fn(...params);
+    if (requestId) {
+      void webview.postMessage({ requestId, result });
+    }
+  } catch (error) {
+    if (requestId) {
+      void webview.postMessage({ requestId, error: String(error) });
+    }
+  }
+}
+
+/**
+ * Routes a webview message to generic invoke or generated handlers.
+ *
+ * Dotted `command` ids use [handleInvoke]. Other ids delegate to the generated
+ * `handleCommand` from annotated controllers (legacy undotted commands).
+ */
+export async function routeWebviewMessage(
+  message: unknown,
+  webview: vscode.Webview,
+  handleCommand: (message: any, webview: vscode.Webview) => Promise<void>,
+): Promise<void> {
+  if (shouldUseInvokeRouting(message)) {
+    await handleInvoke(message, webview);
+    return;
+  }
+
+  await handleCommand(message, webview);
+}


### PR DESCRIPTION
## Summary

Post-MVP improvements on top of the v0.1 MVP: documents the integration-testing roadmap, adds real tests to `example/`, introduces VM-safe `runtime.dart` exports, and ships an agent-assisted DX toolkit (skills, API mapping docs, scaffolded `AGENTS.md`) plus `VSCode.instance.invoke` for dynamic VS Code API calls without `build_runner`.

## Changes

### Roadmap & traceability
- Add [`docs/reference/roadmap.md`](docs/reference/roadmap.md) with a **tiered integration testing** plan (CI build smoke → manual webview checklist → greenfield regression).
- Link roadmap from PRD §9, traceability matrix, README, and doc indexes.
- Replace vague “automated E2E” deferrals with concrete next steps (`scripts/integration_test.sh`, `example/` fixture).

### Example project tests & `runtime.dart`
- Add `example/test/widget_test.dart` and `example/test/api_controller_test.dart` (generated controller + request lifecycle).
- Extract `example/lib/example_app.dart` so widget tests avoid web-only imports.
- Add `lib/runtime.dart` — VM-testable exports for annotated controllers (`annotations`, `VSCodeControllerBase`, `WebViewBridge` stub). Use `package:flutter_vscode/flutter_vscode.dart` in `main()` only when calling `VSCodeWebViewHelper.initialize()`.
- Wire `example/flutter test` into `./scripts/test_all.sh`.

### `VSCode.instance.invoke` (dynamic API calls)
- Add `VSCode.instance.invoke<T>()` for dotted-path VS Code API calls (e.g. `window.showWarningMessage`) **without** running `build_runner`.
- Ship `tool/vscode_invoke.ts` and scaffold it to `src/vscode_invoke.ts`; extension host routes invoke messages via generic dispatch.
- Expand `example/` with annotated commands (`showQuickPick`, `showInputBox` with options map) and a dynamic-invoke demo button.
- Add `test/vscode_test.dart` for invoke behavior.

### Agent-assisted DX toolkit
- Add portable workflow skills under `skills/` (add-command, contributions, extension-host, build, test, troubleshoot).
- Scaffold copies skills to **`agent-skills/`** (tool-neutral) plus **`AGENTS.md`** from `docs/templates/consumer-agents.md`.
- Add [`docs/guides/agent-assisted-development.md`](docs/guides/agent-assisted-development.md) and [`docs/reference/vscode-api-mapping.md`](docs/reference/vscode-api-mapping.md) (decision tree, annotation rules, type mapping, common API patterns).
- Update scaffold template, README, and quickstart to use `runtime.dart` for controllers.

### Docs & scaffold updates
- Message contract and generated-file ownership docs updated for invoke vs annotated flows.
- Scaffold test coverage expanded for agent toolkit outputs (`AGENTS.md`, `agent-skills/`, `vscode_invoke.ts`).

## Test plan

- [ ] `./scripts/test_all.sh` passes (package tests, builder checks, `example/flutter test`)
- [ ] `dart analyze` clean at repo root and in `example/`
- [ ] `cd example && npm run compile` succeeds
- [ ] F5 from `example/` — webview loads; exercise:
  - [ ] **Show Input Box** (annotated `Future<String?>`)
  - [ ] **Show Quick Pick** (annotated list command)
  - [ ] **Invoke Warning (dynamic)** (`VSCode.instance.invoke` without codegen)
- [ ] Fresh scaffold smoke: `dart run flutter_vscode:generate_vscode_extension` in a temp dir → verify `AGENTS.md`, `agent-skills/`, and `src/vscode_invoke.ts` are created

## Notes

- **Invoke vs annotations:** `@VSCodeCommand` remains the typed, codegen-backed path for stable APIs; `VSCode.instance.invoke` is for prototyping and agent-driven experiments.
- **Roadmap follow-up (not in this PR):** `scripts/integration_test.sh --build-only` for Tier 1 CI compile smoke; manual webview checklist script for Tier 2.